### PR TITLE
Use tabs to indent yaml and json files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,5 +4,8 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 
-[*.{js,ts,vue,html}]
+[*.{js,ts,vue,html,json}]
 indent_style = tab
+
+[*.{yml,yaml}]
+indent_size = 4

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: monthly
-  open-pull-requests-limit: 10
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: monthly
-  open-pull-requests-limit: 15
+    - package-ecosystem: github-actions
+      directory: "/"
+      schedule:
+          interval: monthly
+      open-pull-requests-limit: 10
+    - package-ecosystem: npm
+      directory: "/"
+      schedule:
+          interval: monthly
+      open-pull-requests-limit: 15

--- a/package.json
+++ b/package.json
@@ -1,23 +1,25 @@
 {
-  "name": "new-lexeme-special-page",
-  "private": true,
-  "version": "0.0.1",
-  "description": "Form for the upcoming revival of the NewLexeme special page on Wikidata",
-  "main": "main.ts",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/wmde/new-lexeme-special-page.git"
-  },
-  "keywords": [
-    "Wikidata"
-  ],
-  "author": "The Wikidata team",
-  "license": "GPL-2.0-or-later",
-  "bugs": {
-    "url": "https://phabricator.wikimedia.org/project/board/5674/"
-  },
-  "homepage": "https://github.com/wmde/new-lexeme-special-page#readme"
+	"name": "new-lexeme-special-page",
+	"private": true,
+	"version": "0.0.1",
+	"description": "Form for the upcoming revival of the NewLexeme special page on Wikidata",
+	"main": "main.ts",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"prepare": "husky install",
+		"fix": "prettier --write '**/*.{json,yml,yaml}'"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/wmde/new-lexeme-special-page.git"
+	},
+	"keywords": [
+		"Wikidata"
+	],
+	"author": "The Wikidata team",
+	"license": "GPL-2.0-or-later",
+	"bugs": {
+		"url": "https://phabricator.wikimedia.org/project/board/5674/"
+	},
+	"homepage": "https://github.com/wmde/new-lexeme-special-page#readme"
 }


### PR DESCRIPTION
This is basically a follow-up to #4. Some form of linting for this will be added in the next PR.