### PR TITLE
Set up Wikit (vue3compat build)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@vue/compat": "^3.2.30",
+				"@wmde/wikit-vue-components": "^2.1.0-alpha.11",
 				"vue": "^3.2.30"
 			},
 			"devDependencies": {
@@ -925,6 +927,14 @@
 			"integrity": "sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==",
 			"dev": true
 		},
+		"node_modules/@vue/compat": {
+			"version": "3.2.30",
+			"resolved": "https://registry.npmjs.org/@vue/compat/-/compat-3.2.30.tgz",
+			"integrity": "sha512-+k00eNjWNjpuAUQKB9kcGVQr6cTaXLu8bZ4cktiARZXjbnmk4QfdrJiRfayII+KGk3BfpFUIEkBcik/p+uV1Cg==",
+			"peerDependencies": {
+				"vue": "3.2.30"
+			}
+		},
 		"node_modules/@vue/compiler-core": {
 			"version": "3.2.30",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.30.tgz",
@@ -1071,6 +1081,38 @@
 				"@typescript-eslint/parser": "^3.1.0||^5.6.0",
 				"eslint-config-wikimedia": "^0.15.3"
 			}
+		},
+		"node_modules/@wmde/wikit-tokens": {
+			"version": "2.1.0-alpha.11",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.11.tgz",
+			"integrity": "sha512-0udILibLxg9fHKc8qB3/sR12xb9ocTdhOk+VQi2OFpso/0+1uu0S3qzUmC/zzEWK6kZ/9km8QA5SurNkbc6OQQ=="
+		},
+		"node_modules/@wmde/wikit-vue-components": {
+			"version": "2.1.0-alpha.11",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.11.tgz",
+			"integrity": "sha512-rYeDY7O5otjlLukWjRLNMU0TxCqYFS9YIomJqwlb47ygo7q6JjlOEmSGEmTHVxPv3+0tsZDL3MKwDUROMwQEjA==",
+			"dependencies": {
+				"@vue/composition-api": "^1.0.0-beta.20",
+				"@wmde/wikit-tokens": "^2.1.0-alpha.11",
+				"core-js": "^3.7.0",
+				"lodash.debounce": "^4.0.8",
+				"lodash.isequal": "^4.5.0",
+				"ress": "^3.0.0",
+				"vue": "^2.6.12"
+			}
+		},
+		"node_modules/@wmde/wikit-vue-components/node_modules/@vue/composition-api": {
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.4.6.tgz",
+			"integrity": "sha512-UP359OJ0G0Zli603/i9fhXFmNtZUSrypSFyqClMxizp8ezlaMK2GCmHgy3qyrRnO/xjcDAx09vvXPwNFtxHPtQ==",
+			"peerDependencies": {
+				"vue": ">= 2.5 < 3"
+			}
+		},
+		"node_modules/@wmde/wikit-vue-components/node_modules/vue": {
+			"version": "2.6.14",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+			"integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
 		},
 		"node_modules/acorn": {
 			"version": "8.7.0",
@@ -1509,7 +1551,6 @@
 			"version": "3.21.0",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
 			"integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ==",
-			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
 				"type": "opencollective",
@@ -4079,6 +4120,16 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
+		"node_modules/lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+		},
+		"node_modules/lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
 		"node_modules/lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -5170,6 +5221,11 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/ress": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ress/-/ress-3.0.0.tgz",
+			"integrity": "sha512-MTPto7t44AawqmSbEmvMKoSMWPnxjaTuHf94s7RjWxuSGFN0o8/b+6yOwkaC50+Vihjsu6ODUEQR397gTMn57w=="
 		},
 		"node_modules/restore-cursor": {
 			"version": "3.1.0",
@@ -6972,6 +7028,12 @@
 				}
 			}
 		},
+		"@vue/compat": {
+			"version": "3.2.30",
+			"resolved": "https://registry.npmjs.org/@vue/compat/-/compat-3.2.30.tgz",
+			"integrity": "sha512-+k00eNjWNjpuAUQKB9kcGVQr6cTaXLu8bZ4cktiARZXjbnmk4QfdrJiRfayII+KGk3BfpFUIEkBcik/p+uV1Cg==",
+			"requires": {}
+		},
 		"@vue/compiler-core": {
 			"version": "3.2.30",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.30.tgz",
@@ -7102,6 +7164,38 @@
 			"integrity": "sha512-ltrtMFeDm/u696lVO96JxSDG83aItgGwo9YTSZW315YEgP2/ox4OJbJA4Dr+iR1uqrEm12wLMu05MJcqMWcgcw==",
 			"dev": true,
 			"requires": {}
+		},
+		"@wmde/wikit-tokens": {
+			"version": "2.1.0-alpha.11",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-2.1.0-alpha.11.tgz",
+			"integrity": "sha512-0udILibLxg9fHKc8qB3/sR12xb9ocTdhOk+VQi2OFpso/0+1uu0S3qzUmC/zzEWK6kZ/9km8QA5SurNkbc6OQQ=="
+		},
+		"@wmde/wikit-vue-components": {
+			"version": "2.1.0-alpha.11",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-2.1.0-alpha.11.tgz",
+			"integrity": "sha512-rYeDY7O5otjlLukWjRLNMU0TxCqYFS9YIomJqwlb47ygo7q6JjlOEmSGEmTHVxPv3+0tsZDL3MKwDUROMwQEjA==",
+			"requires": {
+				"@vue/composition-api": "^1.0.0-beta.20",
+				"@wmde/wikit-tokens": "^2.1.0-alpha.11",
+				"core-js": "^3.7.0",
+				"lodash.debounce": "^4.0.8",
+				"lodash.isequal": "^4.5.0",
+				"ress": "^3.0.0",
+				"vue": "^2.6.12"
+			},
+			"dependencies": {
+				"@vue/composition-api": {
+					"version": "1.4.6",
+					"resolved": "https://registry.npmjs.org/@vue/composition-api/-/composition-api-1.4.6.tgz",
+					"integrity": "sha512-UP359OJ0G0Zli603/i9fhXFmNtZUSrypSFyqClMxizp8ezlaMK2GCmHgy3qyrRnO/xjcDAx09vvXPwNFtxHPtQ==",
+					"requires": {}
+				},
+				"vue": {
+					"version": "2.6.14",
+					"resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+					"integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
+				}
+			}
 		},
 		"acorn": {
 			"version": "8.7.0",
@@ -7427,8 +7521,7 @@
 		"core-js": {
 			"version": "3.21.0",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.21.0.tgz",
-			"integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ==",
-			"dev": true
+			"integrity": "sha512-YUdI3fFu4TF/2WykQ2xzSiTQdldLB4KVuL9WeAy5XONZYt5Cun/fpQvctoKbCgvPhmzADeesTk/j2Rdx77AcKQ=="
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
@@ -9267,6 +9360,16 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
+		"lodash.debounce": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+		},
 		"lodash.memoize": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -10093,6 +10196,11 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true
+		},
+		"ress": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/ress/-/ress-3.0.0.tgz",
+			"integrity": "sha512-MTPto7t44AawqmSbEmvMKoSMWPnxjaTuHf94s7RjWxuSGFN0o8/b+6yOwkaC50+Vihjsu6ODUEQR397gTMn57w=="
 		},
 		"restore-cursor": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
 	},
 	"homepage": "https://github.com/wmde/new-lexeme-special-page#readme",
 	"dependencies": {
+		"@vue/compat": "^3.2.30",
+		"@wmde/wikit-vue-components": "^2.1.0-alpha.11",
 		"vue": "^3.2.30"
 	},
 	"devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,8 @@
 // This starter template is using Vue 3 <script setup> SFCs
 // Check out https://v3.vuejs.org/api/sfc-script-setup.html#sfc-script-setup
 import HelloWorld from './components/HelloWorld.vue';
+
+import '@wmde/wikit-vue-components/dist/wikit-vue-components.css';
 </script>
 
 <template>

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue';
+import { Button } from '@wmde/wikit-vue-components';
 
 defineProps<{ msg: string }>();
 
@@ -19,9 +20,9 @@ const count = ref( 0 );
 		<a href="https://v3.vuejs.org/" target="_blank">Vue 3 Docs</a>
 	</p>
 
-	<button type="button" @click="count++">
+	<Button @click.native="count++">
 		count is: {{ count }}
-	</button>
+	</Button>
 	<p>
 		Edit
 		<code>components/HelloWorld.vue</code> to test hot module replacement.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,30 @@
+import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
 // https://vitejs.dev/config/
 export default defineConfig( {
-	plugins: [ vue() ],
+	resolve: {
+		alias: {
+			'vue': '@vue/compat',
+			'@vue/composition-api': '@vue/compat',
+			'@wmde/wikit-vue-components/dist/wikit-vue-components.css': resolve(
+				__dirname,
+				'node_modules/@wmde/wikit-vue-components/dist/wikit-vue-components.css',
+			),
+			'@wmde/wikit-vue-components': resolve(
+				__dirname,
+				'node_modules/@wmde/wikit-vue-components/dist/wikit-vue-components-vue3compat.common.js',
+			),
+		},
+	},
+	plugins: [ vue( {
+		template: {
+			compilerOptions: {
+				compatConfig: {
+					MODE: 2,
+				},
+			},
+		},
+	} ) ],
 } );


### PR DESCRIPTION
Use the migration build, mapping not only `vue` but also `@vue/composition-api` (used by Wikit) to `@vue/compat`. For `@click.native` to work, we need `MODE: 2` in the Vite config, or at least I haven’t yet found a way to make it work in `MODE: 3`. At some point, we’re hoping to have a properly Vue 3-compatible (subset of) Wikit, so that we can drop the migration build and use Vue 3 alone.

Bug: T301145