### PR TITLE
Fix lint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,8 @@ module.exports = {
 
 		// resetting this back to the default value, to comply with modern vite conventions
 		'vue/component-tags-order': [ 'error', { order: [ [ 'script', 'template' ], 'style' ] } ],
+
+		// we still need to use some legacy APIs to interact with the vue3compat build of Wikit
+		'vue/no-deprecated-v-on-native-modifier': 'off',
 	},
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,5 @@
+/* eslint quote-props: [ "error", "consistent-as-needed" ] */
+
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';


### PR DESCRIPTION
These were accidentally introduced in #9, which was merged after linting had been added in the meantime.

In vite.config.js, reconfigure the quote-props lint to “consistent as needed” mode, because I don’t think it makes sense to unquote only the “vue” prop of the alias config.