### PR TITLE
Add rudimentary dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,8 @@ Please report bugs on [phabricator](https://phabricator.wikimedia.org/project/vi
 
 ## Local Development
 
-TBA
+_**Prerequisits: This repository requires node v16 and up**_
+
+1. Clone this repository
+2. Install dependecies with `npm i`
+3. Test and lint with `npm test`


### PR DESCRIPTION
This change adds a bare-bones dev instructions to our documentation, mainly as a way to test mirroring with phabricator diffusion.

Bug: [T301335](https://phabricator.wikimedia.org/T301335)