### PR TITLE
Add missing styleMock.js file

### DIFF
--- a/tests/mocks/styleMock.js
+++ b/tests/mocks/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};


### PR DESCRIPTION
It’s already referenced in jest.config.js, but didn’t exist yet. This didn’t come up before because we didn’t have a test pulling in `App.vue` yet, but we’ll want such a test at some point.