### PR TITLE
Add i18n plugin

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -3,20 +3,24 @@
 <script setup lang="ts">
 import { useStore } from 'vuex';
 import { Button as WikitButton } from '@wmde/wikit-vue-components';
-import { computed } from 'vue';
+import { computed, inject } from 'vue';
 import { DELAYED_INCREMENT } from '@/store/actions';
+import Messages, { MessagesKey } from '@/plugins/MessagesPlugin/Messages';
 
 defineProps<{ msg: string }>();
 
 const store = useStore();
 const count = computed( () => store.state.count );
 const increment = () => store.dispatch( DELAYED_INCREMENT, { delay: 300 } );
+const $messages = inject( MessagesKey, new Messages() );
 </script>
 
 <template>
 	<h1>{{ msg }}</h1>
 
 	<p>See <code>README.md</code> for more information.</p>
+
+	<p>i18n example: {{ $messages.get( 'wikibaselexeme-newlexeme-lemma' ) }}</p>
 
 	<p>
 		<a href="https://vitejs.dev/guide/features.html" target="_blank">

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,13 +4,21 @@ import {
 } from 'vue';
 import store from './store';
 import App from './App.vue';
+import Messages, { MessagesKey } from './plugins/MessagesPlugin/Messages';
+import MessagesRepository from './plugins/MessagesPlugin/MessagesRepository';
 
 interface Config {
 	rootSelector: string;
 }
 
-export default function createAndMount( config: Config ): ComponentPublicInstance {
-	return createApp( App )
-		.use( store )
-		.mount( config.rootSelector );
+export default function createAndMount(
+	config: Config,
+	messageRepo?: MessagesRepository,
+): ComponentPublicInstance {
+	const app = createApp( App );
+	app.use( store );
+
+	app.provide( MessagesKey, new Messages( messageRepo ) );
+
+	return app.mount( config.rootSelector );
 }

--- a/src/plugins/MessagesPlugin/MessageKeys.ts
+++ b/src/plugins/MessagesPlugin/MessageKeys.ts
@@ -1,0 +1,4 @@
+type MessageKeys =
+	'wikibaselexeme-newlexeme-lemma';
+
+export default MessageKeys;

--- a/src/plugins/MessagesPlugin/Messages.ts
+++ b/src/plugins/MessagesPlugin/Messages.ts
@@ -7,8 +7,8 @@ import { InjectionKey } from 'vue';
  *
  * FIXME: write something about when to use getText vs get
  *
- * `this.$messages.get( this.$messages.KEYS.LEMMA_INPUT_LABEL )`
- * `this.$messages.getText( this.$messages.KEYS.LEMMA_INPUT_LABEL )`
+ * `this.$messages.get( 'wikibaselexeme-newlexeme-lemma' )`
+ * `this.$messages.getText( 'wikibaselexeme-newlexeme-lemma' )`
  */
 export default class Messages {
 

--- a/src/plugins/MessagesPlugin/Messages.ts
+++ b/src/plugins/MessagesPlugin/Messages.ts
@@ -1,0 +1,41 @@
+import MessagesRepository from '@/plugins/MessagesPlugin/MessagesRepository';
+import MessageKeys from '@/plugins/MessagesPlugin/MessageKeys';
+import { InjectionKey } from 'vue';
+
+/**
+ * Usage (assuming this has been registered as a Vue plugin):
+ *
+ * FIXME: write something about when to use getText vs get
+ *
+ * `this.$messages.get( this.$messages.KEYS.LEMMA_INPUT_LABEL )`
+ * `this.$messages.getText( this.$messages.KEYS.LEMMA_INPUT_LABEL )`
+ */
+export default class Messages {
+
+	private readonly messagesRepository: MessagesRepository;
+
+	public constructor( messagesRepository?: MessagesRepository ) {
+		if ( !messagesRepository ) {
+			this.messagesRepository = {
+				get( messageKey ) {
+					return `⧼${messageKey}⧽`;
+				},
+				getText( messageKey ) {
+					return `⧼${messageKey}⧽`;
+				},
+			};
+			return;
+		}
+		this.messagesRepository = messagesRepository;
+	}
+
+	public get( messageKey: MessageKeys, ...params: readonly ( string|HTMLElement )[] ): string {
+		return this.messagesRepository.get( messageKey, ...params );
+	}
+
+	public getUnescaped( messageKey: MessageKeys, ...params: readonly string[] ): string {
+		return this.messagesRepository.getText( messageKey, ...params );
+	}
+}
+
+export const MessagesKey: InjectionKey<Messages> = Symbol( 'Messages' );

--- a/src/plugins/MessagesPlugin/MessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/MessagesRepository.ts
@@ -1,0 +1,14 @@
+export default interface MessagesRepository {
+	/**
+	 * @return HTML
+	 * Any bad tags in the message source are escaped.
+	 */
+	get( messageKey: string, ...params: readonly ( string| HTMLElement )[] ): string;
+
+	/**
+	 * @return plain text
+	 * HTML-significant characters in the message source are not escaped,
+	 * and the result must not be used as HTML.
+	 */
+	getText( messageKey: string, ...params: readonly string[] ): string;
+}

--- a/tests/unit/plugins/Messages.test.ts
+++ b/tests/unit/plugins/Messages.test.ts
@@ -1,0 +1,26 @@
+import MessagesRepository from '@/plugins/MessagesPlugin/MessagesRepository';
+import Messages from '@/plugins/MessagesPlugin/Messages';
+import MessageKeys from '@/plugins/MessagesPlugin/MessageKeys';
+
+describe( 'Messages', () => {
+
+	it( 'forwards to the MessagesRepository', () => {
+		const messagesRepository: MessagesRepository = {
+			get: jest.fn( ( key ) => `test ${key}` ),
+			getText: jest.fn( ( key ) => `test text ${key}` ),
+		};
+		const messages = new Messages( messagesRepository );
+
+		const message = messages.get( 'key' as MessageKeys );
+		const messageText = messages.getUnescaped( 'key' as MessageKeys );
+
+		expect( messagesRepository.get ).toHaveBeenCalledTimes( 1 );
+		expect( messagesRepository.get ).toHaveBeenCalledWith( 'key' );
+		expect( message ).toBe( 'test key' );
+		expect( messageText ).toBe( 'test text key' );
+
+		const parameter = 'something';
+		messages.get( 'key' as MessageKeys, parameter );
+		expect( messagesRepository.get ).toHaveBeenCalledWith( 'key', parameter );
+	} );
+} );


### PR DESCRIPTION
In the compositionApi we cannot access `this`, so using a global instance method does not work. The established way to deal with this in Vue 3 is to use provide/inject.

Using provide/inject works well, with the one exception that requires a fallback or will be typed `Messages|undefined`. This leaves a couple of non-ideal solutions:
1. assert it as non-null it with `!`
2. cast it with `as Messages`
3. have some if-guard that throws an Error
4. Provide a simple fallback

I went with option 4 and extended the original Messages class from [Data Bridge] with a fallback if no repository is provided. This also makes the initialization in the index.html easier and still allows for a more elaborate mock in the future, if we want it.

[Data Bridge]: https://github.com/wikimedia/Wikibase/blob/f73e98507da6e494ffaa1fe9c15b787a527ba33a/client/data-bridge/src/presentation/plugins/MessagesPlugin/Messages.ts

Bug: T301570