### PR TITLE
fix Netlify hosting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vue-tsc --noEmit && vite build",
+		"buildPreview": "BUILD_AS_APP=1 vite build",
 		"fix": "run-s fix:*",
 		"fix:prettier": "prettier --write '**/*.{json,yml,yaml}'",
 		"fix:eslint": "eslint --fix --ext .js,.ts,.vue --ignore-path .gitignore . --ignore-pattern 'cypress'",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,17 @@
 /* eslint quote-props: [ "error", "consistent-as-needed" ] */
 
 import { resolve } from 'path';
-import { defineConfig } from 'vite';
+import { BuildOptions, defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
-// https://vitejs.dev/config/
-export default defineConfig( {
-	build: {
+function getBuildConfig( isAappBuild: bool ): BuildOptions {
+	if ( isAappBuild ) {
+		return {
+			target: 'es2015',
+		};
+	}
+
+	return {
 		target: 'es2015',
 		lib: {
 			entry: resolve( __dirname, 'src/main.ts' ),
@@ -17,7 +22,12 @@ export default defineConfig( {
 		rollupOptions: {
 			external: [ '@vue/compat', 'vue', 'vuex' ],
 		},
-	},
+	};
+}
+
+// https://vitejs.dev/config/
+export default defineConfig( {
+	build: getBuildConfig( !!process.env.BUILD_AS_APP ),
 	resolve: {
 		alias: {
 			'vue': '@vue/compat',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,8 +4,8 @@ import { resolve } from 'path';
 import { BuildOptions, defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 
-function getBuildConfig( isAappBuild: bool ): BuildOptions {
-	if ( isAappBuild ) {
+function getBuildConfig( isAppBuild: bool ): BuildOptions {
+	if ( isAppBuild ) {
 		return {
 			target: 'es2015',
 		};


### PR DESCRIPTION
Netlify actually needs an index.html in the dist directory. However this
is not added for a library build. So this creates an extra build command
to keep building it as an app that makes still use of the index.html,
link `npm run dev`. This skips the type checking as the build currently
runs on Netlify itself and there we only have a limited amount of build
minutes included. Rather the type checking should be part of the "code
quality" CI job.

This Netlify hosting was broken in #19 / 171d33f

* [ ] Open question: Do we want this to be built in `--mode development`? 
This would allow devtools to work, but might in theory have slight differences
to production?
* [ ] Also: this will need adjustments to the config in Netlify to work. (that is, to the build command)