### PR TITLE
Run type checks in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
 		"lint:stylelint": "stylelint '**/*.{css,scss,vue}'",
 		"preview": "vite preview",
 		"prepare": "husky install",
-		"test": "run-s lint test-only",
+		"test": "run-s lint check-types test-only",
 		"test-only": "run-s test:*",
 		"test:unit": "jest",
 		"test:cypress": "cypress run",
+		"check-types": "vue-tsc --noEmit",
 		"cypress:open": "cypress open"
 	},
 	"repository": {


### PR DESCRIPTION
This ensures that types are checked in our normal CI runs. Previously,
types were only checked as part of the `build` script, which is not
normally run in CI.

It is moved to its own script name, because it is not a test per se and
it is way too slow for linting.