### PR TITLE
Really run type checks in CI

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -18,5 +18,8 @@ jobs:
             - name: Lint Files
               run: npm run lint
 
+            - name: Check Types
+              run: npm run check-types
+
             - name: Run Tests
               run: npm run test-only


### PR DESCRIPTION
Our CI runs commands separately, not `npm test` as a whole.