### PR TITLE
Add basic input for lexical category

### DIFF
--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { TextInput } from '@wmde/wikit-vue-components';
+import { useMessages } from '@/plugins/MessagesPlugin/Messages';
+
+interface Props {
+	modelValue: string;
+}
+
+defineProps<Props>();
+
+defineEmits( [ 'update:modelValue' ] );
+
+const messages = useMessages();
+</script>
+
+<script lang="ts">
+export default {
+	compatConfig: {
+		MODE: 3,
+	},
+};
+</script>
+
+<template>
+	<text-input
+		class="mw-wbl-snl-lexical-category-input"
+		:label="messages.get( 'wikibaselexeme-newlexeme-lexicalcategory' )"
+		:placeholder="messages.get( 'wikibaselexeme-newlexeme-lexicalcategory-placeholder' )"
+		name="lexicalcategory"
+		required
+		pattern="Q[1-9][0-9]*"
+		:value="modelValue"
+		@input="$emit( 'update:modelValue', $event )"
+	/>
+</template>

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -4,7 +4,11 @@ import { useStore } from 'vuex';
 import { Button as WikitButton } from '@wmde/wikit-vue-components';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import LemmaInput from '@/components/LemmaInput.vue';
-import { UPDATE_LEMMA } from '@/store/actions';
+import LexicalCategoryInput from '@/components/LexicalCategoryInput.vue';
+import {
+	UPDATE_LEMMA,
+	UPDATE_LEXICAL_CATEGORY,
+} from '@/store/actions';
 
 const $messages = useMessages();
 const store = useStore();
@@ -14,6 +18,14 @@ const lemma = computed( {
 	},
 	set( newLemmaValue: string ): void {
 		store.dispatch( UPDATE_LEMMA, newLemmaValue );
+	},
+} );
+const lexicalCategory = computed( {
+	get(): string {
+		return store.state.lexicalCategory;
+	},
+	set( newLexicalCategory: string ): void {
+		store.dispatch( UPDATE_LEXICAL_CATEGORY, newLexicalCategory );
 	},
 } );
 </script>
@@ -30,6 +42,9 @@ export default {
 	<form class="new-lexeme-form">
 		<lemma-input
 			v-model="lemma"
+		/>
+		<lexical-category-input
+			v-model="lexicalCategory"
 		/>
 		<wikit-button
 			class="form-button-submit"

--- a/src/plugins/MessagesPlugin/MessageKeys.ts
+++ b/src/plugins/MessagesPlugin/MessageKeys.ts
@@ -1,6 +1,8 @@
 type MessageKeys
  = 'wikibaselexeme-newlexeme-lemma'
  | 'wikibaselexeme-newlexeme-lemma-placeholder'
+ | 'wikibaselexeme-newlexeme-lexicalcategory'
+ | 'wikibaselexeme-newlexeme-lexicalcategory-placeholder'
  | 'wikibaselexeme-newlexeme-submit'
  | 'wikibaselexeme-newlexeme-error-no-lemma'
  | 'wikibaselexeme-newlexeme-error-lemma-is-too-long';

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -1,3 +1,4 @@
 export default interface RootState {
 	lemma: string;
+	lexicalCategory: string;
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -8,14 +8,21 @@
 
 import { ActionContext } from 'vuex';
 import RootState from './RootState';
-import { SET_LEMMA } from './mutations';
+import {
+	SET_LEMMA,
+	SET_LEXICAL_CATEGORY,
+} from './mutations';
 
 type RootContext = ActionContext<RootState, RootState>;
 
 export const UPDATE_LEMMA = 'updateLemma';
+export const UPDATE_LEXICAL_CATEGORY = 'updateLexicalCategory';
 
 export default {
 	[ UPDATE_LEMMA ]( { commit }: RootContext, lemma: string ): void {
 		commit( SET_LEMMA, lemma );
+	},
+	[ UPDATE_LEXICAL_CATEGORY ]( { commit }: RootContext, lexicalCategory: string ): void {
+		commit( SET_LEXICAL_CATEGORY, lexicalCategory );
 	},
 };

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,6 +14,7 @@ export default createStore( {
 	state(): RootState {
 		return {
 			lemma: '',
+			lexicalCategory: '',
 		};
 	},
 	mutations,

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -9,9 +9,13 @@
 import RootState from './RootState';
 
 export const SET_LEMMA = 'setLemma';
+export const SET_LEXICAL_CATEGORY = 'setLexicalCategory';
 
 export default {
 	[ SET_LEMMA ]( state: RootState, lemma: string ): void {
 		state.lemma = lemma;
+	},
+	[ SET_LEXICAL_CATEGORY ]( state: RootState, lexicalCategory: string ): void {
+		state.lexicalCategory = lexicalCategory;
 	},
 };

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -15,8 +15,17 @@ describe( 'NewLexemeForm', () => {
 		const wrapper = mountForm();
 		const lemmaInput = wrapper.find( '.mw-wbl-snl-lemma-input input' );
 
-		lemmaInput.setValue( 'foo' );
+		await lemmaInput.setValue( 'foo' );
 
 		expect( store.state.lemma ).toBe( 'foo' );
+	} );
+
+	it( 'updates the store if something is entered into the lexical category input', async () => {
+		const wrapper = mountForm();
+		const lexicalCategoryInput = wrapper.find( '.mw-wbl-snl-lexical-category-input input' );
+
+		await lexicalCategoryInput.setValue( 'foo' );
+
+		expect( store.state.lexicalCategory ).toBe( 'foo' );
 	} );
 } );


### PR DESCRIPTION
Just a plain text field for now, the proper lookup will come later.

Also, add `await` in the integration test, my IDE tells me `setValue()` should be awaited (though the tests seem to work without it).

Bug: T301783