### PR TITLE
Directly use mutations in NewLexemeForm

### DIFF
--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -6,9 +6,9 @@ import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import LemmaInput from '@/components/LemmaInput.vue';
 import LexicalCategoryInput from '@/components/LexicalCategoryInput.vue';
 import {
-	UPDATE_LEMMA,
-	UPDATE_LEXICAL_CATEGORY,
-} from '@/store/actions';
+	SET_LEMMA,
+	SET_LEXICAL_CATEGORY,
+} from '@/store/mutations';
 
 const $messages = useMessages();
 const store = useStore();
@@ -17,7 +17,7 @@ const lemma = computed( {
 		return store.state.lemma;
 	},
 	set( newLemmaValue: string ): void {
-		store.dispatch( UPDATE_LEMMA, newLemmaValue );
+		store.commit( SET_LEMMA, newLemmaValue );
 	},
 } );
 const lexicalCategory = computed( {
@@ -25,7 +25,7 @@ const lexicalCategory = computed( {
 		return store.state.lexicalCategory;
 	},
 	set( newLexicalCategory: string ): void {
-		store.dispatch( UPDATE_LEXICAL_CATEGORY, newLexicalCategory );
+		store.commit( SET_LEXICAL_CATEGORY, newLexicalCategory );
 	},
 } );
 </script>

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -6,23 +6,27 @@
  * @see https://vuex.vuejs.org/guide/structure.html
  */
 
+/*
+ * Actions should be used for complex or asynchronous changes,
+ * otherwise it’s preferred to directly use mutations.
+ * Currently, there are no actions, but see the commented-out code below for guidance.
+ */
+
+/*
 import { ActionContext } from 'vuex';
 import RootState from './RootState';
 import {
-	SET_LEMMA,
-	SET_LEXICAL_CATEGORY,
+	MUTATION_NAME,
 } from './mutations';
+*/
 
-type RootContext = ActionContext<RootState, RootState>;
+// type RootContext = ActionContext<RootState, RootState>;
 
-export const UPDATE_LEMMA = 'updateLemma';
-export const UPDATE_LEXICAL_CATEGORY = 'updateLexicalCategory';
+// export const ACTION_NAME = 'actionName';
 
 export default {
-	[ UPDATE_LEMMA ]( { commit }: RootContext, lemma: string ): void {
-		commit( SET_LEMMA, lemma );
-	},
-	[ UPDATE_LEXICAL_CATEGORY ]( { commit }: RootContext, lexicalCategory: string ): void {
-		commit( SET_LEXICAL_CATEGORY, lexicalCategory );
-	},
+	/* async [ ACTION_NAME ]( { commit }: RootContext, payload ): Promise<void> {
+		await ...;
+		commit( MUTATION_NAME, payload );
+	}, */
 };


### PR DESCRIPTION
The actions aren’t worth the overhead here. Leave some commented-out guidance behind in `actions.ts`, because we’ll surely want some actions again at some point.