### PR TITLE
Enforce class prefixes

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -10,7 +10,7 @@
 		"selector-max-id": 1,
 		"liberty/use-logical-spec": true,
 		"selector-class-pattern": [
-			"^wbl-snl-[a-z0-9]+$",
+			"^wbl-snl-[-_a-z0-9]+$",
 			{
 				"resolveNestedSelectors": true,
 				"message": "Selector class names should be lowercase and prefixed with wbl-snl-*."

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -8,6 +8,13 @@
 	"rules": {
 		"indentation": "tab",
 		"selector-max-id": 1,
-		"liberty/use-logical-spec": true
+		"liberty/use-logical-spec": true,
+		"selector-class-pattern": [
+			"^wbl-snl-[a-z0-9]+$",
+			{
+				"resolveNestedSelectors": true,
+				"message": "Selector class names should be lowercase and prefixed with wbl-snl-*."
+			}
+		]
 	}
 }

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -39,7 +39,7 @@ export default {
 </script>
 
 <template>
-	<form class="new-lexeme-form">
+	<form class="wbl-snl-form">
 		<lemma-input
 			v-model="lemma"
 		/>
@@ -59,7 +59,7 @@ export default {
 <style scoped lang="scss">
 @import "@wmde/wikit-tokens/variables";
 
-.new-lexeme-form {
+.wbl-snl-form {
 	// Box model
 	padding: $dimension-layout-small;
 


### PR DESCRIPTION
This change adds a linting rule based on the rule that was proposed in Mattermost and the discussion the ensued. It is related to our first HTML and CSS setup and the stylelint setup task.

Bug: [T301234](https://phabricator.wikimedia.org/T301234)
Bug: [T300888](https://phabricator.wikimedia.org/T300888)