### PR TITLE
Add licensing information

### DIFF
--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -86,6 +86,7 @@ export default {
 		/>
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 		<input
 			type="hidden"
 			name="wpEditToken"
@@ -97,6 +98,9 @@ export default {
 =======
 		<p class="wbl-snl-copyright wbl-snl-small-text" v-html="copyrightText" />
 >>>>>>> Add styles to the copyright info
+=======
+		<p class="wbl-snl-copyright" v-html="copyrightText" />
+>>>>>>> removing small text class and unifying mixin inclusion under copyright class
 		<div>
 			<wikit-button
 				class="form-button-submit"
@@ -129,15 +133,21 @@ export default {
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 .wbl-snl-copyright {
 	@include small-text;
 =======
 .wbl-snl-small-text {
+=======
+.wbl-snl-copyright {
+>>>>>>> removing small text class and unifying mixin inclusion under copyright class
 	@include small-text;
-}
 
+<<<<<<< HEAD
 .wbl-snl-copyright {
 >>>>>>> Add styles to the copyright info
+=======
+>>>>>>> removing small text class and unifying mixin inclusion under copyright class
 	font-style: italic;
 }
 

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -40,6 +40,7 @@ const lexicalCategory = computed( {
 } );
 const token = computed( () => store.state.token );
 const submitMsg = $messages.get( 'wikibaselexeme-newlexeme-submit' );
+<<<<<<< HEAD
 const termsOfUseTitle = $messages.get( 'copyrightpage' );
 const copyrightText = $messages.get(
 	'wikibase-shortcopyrightwarning',
@@ -47,6 +48,15 @@ const copyrightText = $messages.get(
 	termsOfUseTitle,
 	store.state.config.licenseUrl,
 	store.state.config.licenseName,
+=======
+const termsOfUseURL = 'https://foundation.wikimedia.org/wiki/Terms_of_Use';
+const copyrightText = $messages.get(
+	'wikibase-shortcopyrightwarning',
+	submitMsg,
+	termsOfUseURL,
+	store.state.config.cc0Url,
+	store.state.config.cc0Text,
+>>>>>>> Add cc0 link text and url to store and inject into createAndMount
 );
 </script>
 

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -108,6 +108,7 @@ export default {
 
 .wbl-snl-copyright {
 	@include small-text;
+
 	font-style: italic;
 }
 

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -40,7 +40,6 @@ const lexicalCategory = computed( {
 } );
 const token = computed( () => store.state.token );
 const submitMsg = $messages.get( 'wikibaselexeme-newlexeme-submit' );
-<<<<<<< HEAD
 const termsOfUseTitle = $messages.get( 'copyrightpage' );
 const copyrightText = $messages.get(
 	'wikibase-shortcopyrightwarning',
@@ -48,20 +47,6 @@ const copyrightText = $messages.get(
 	termsOfUseTitle,
 	store.state.config.licenseUrl,
 	store.state.config.licenseName,
-=======
-const termsOfUseURL = 'https://foundation.wikimedia.org/wiki/Terms_of_Use';
-const copyrightText = $messages.get(
-	'wikibase-shortcopyrightwarning',
-	submitMsg,
-	termsOfUseURL,
-<<<<<<< HEAD
-	store.state.config.cc0Url,
-	store.state.config.cc0Text,
->>>>>>> Add cc0 link text and url to store and inject into createAndMount
-=======
-	store.state.config.licenseUrl,
-	store.state.config.licenseName,
->>>>>>> Add parameters to store dynamically upon its creation
 );
 </script>
 
@@ -84,23 +69,12 @@ export default {
 		<lexical-category-input
 			v-model="lexicalCategory"
 		/>
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
 		<input
 			type="hidden"
 			name="wpEditToken"
 			:value="token"
 		>
-=======
->>>>>>> Restore lost divs
 		<p class="wbl-snl-copyright" v-html="copyrightText" />
-=======
-		<p class="wbl-snl-copyright wbl-snl-small-text" v-html="copyrightText" />
->>>>>>> Add styles to the copyright info
-=======
-		<p class="wbl-snl-copyright" v-html="copyrightText" />
->>>>>>> removing small text class and unifying mixin inclusion under copyright class
 		<div>
 			<wikit-button
 				class="form-button-submit"
@@ -132,22 +106,8 @@ export default {
 	border-color: $border-color-base-subtle;
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 .wbl-snl-copyright {
 	@include small-text;
-=======
-.wbl-snl-small-text {
-=======
-.wbl-snl-copyright {
->>>>>>> removing small text class and unifying mixin inclusion under copyright class
-	@include small-text;
-
-<<<<<<< HEAD
-.wbl-snl-copyright {
->>>>>>> Add styles to the copyright info
-=======
->>>>>>> removing small text class and unifying mixin inclusion under copyright class
 	font-style: italic;
 }
 

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -85,6 +85,7 @@ export default {
 			v-model="lexicalCategory"
 		/>
 <<<<<<< HEAD
+<<<<<<< HEAD
 		<input
 			type="hidden"
 			name="wpEditToken"
@@ -93,6 +94,9 @@ export default {
 =======
 >>>>>>> Restore lost divs
 		<p class="wbl-snl-copyright" v-html="copyrightText" />
+=======
+		<p class="wbl-snl-copyright wbl-snl-small-text" v-html="copyrightText" />
+>>>>>>> Add styles to the copyright info
 		<div>
 			<wikit-button
 				class="form-button-submit"
@@ -124,8 +128,16 @@ export default {
 	border-color: $border-color-base-subtle;
 }
 
+<<<<<<< HEAD
 .wbl-snl-copyright {
 	@include small-text;
+=======
+.wbl-snl-small-text {
+	@include small-text;
+}
+
+.wbl-snl-copyright {
+>>>>>>> Add styles to the copyright info
 	font-style: italic;
 }
 

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -84,11 +84,14 @@ export default {
 		<lexical-category-input
 			v-model="lexicalCategory"
 		/>
+<<<<<<< HEAD
 		<input
 			type="hidden"
 			name="wpEditToken"
 			:value="token"
 		>
+=======
+>>>>>>> Restore lost divs
 		<p class="wbl-snl-copyright" v-html="copyrightText" />
 		<div>
 			<wikit-button

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -74,6 +74,7 @@ export default {
 			name="wpEditToken"
 			:value="token"
 		>
+		<!-- eslint-disable-next-line vue/no-v-html -->
 		<p class="wbl-snl-copyright" v-html="copyrightText" />
 		<div>
 			<wikit-button

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -39,6 +39,15 @@ const lexicalCategory = computed( {
 	},
 } );
 const token = computed( () => store.state.token );
+const submitMsg = $messages.get( 'wikibaselexeme-newlexeme-submit' );
+const termsOfUseTitle = $messages.get( 'copyrightpage' );
+const copyrightText = $messages.get(
+	'wikibase-shortcopyrightwarning',
+	submitMsg,
+	termsOfUseTitle,
+	store.state.config.licenseUrl,
+	store.state.config.licenseName,
+);
 </script>
 
 <script lang="ts">
@@ -65,13 +74,14 @@ export default {
 			name="wpEditToken"
 			:value="token"
 		>
+		<p class="wbl-snl-copyright" v-html="copyrightText" />
 		<div>
 			<wikit-button
 				class="form-button-submit"
 				type="progressive"
 				variant="primary"
 			>
-				{{ $messages.get( 'wikibaselexeme-newlexeme-submit' ) }}
+				{{ submitMsg }}
 			</wikit-button>
 		</div>
 	</form>
@@ -79,6 +89,7 @@ export default {
 
 <style scoped lang="scss">
 @import "@wmde/wikit-tokens/variables";
+@import "@wmde/wikit-vue-components/src/styles/mixins/Typography";
 
 .wbl-snl-form {
 	& > * + * {
@@ -94,4 +105,10 @@ export default {
 	border-radius: $border-radius-base;
 	border-color: $border-color-base-subtle;
 }
+
+.wbl-snl-copyright {
+	@include small-text;
+	font-style: italic;
+}
+
 </style>

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -54,9 +54,14 @@ const copyrightText = $messages.get(
 	'wikibase-shortcopyrightwarning',
 	submitMsg,
 	termsOfUseURL,
+<<<<<<< HEAD
 	store.state.config.cc0Url,
 	store.state.config.cc0Text,
 >>>>>>> Add cc0 link text and url to store and inject into createAndMount
+=======
+	store.state.config.licenseUrl,
+	store.state.config.licenseName,
+>>>>>>> Add parameters to store dynamically upon its creation
 );
 </script>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,13 +10,13 @@ import MessagesRepository from './plugins/MessagesPlugin/MessagesRepository';
 interface Config {
 	rootSelector: string;
 	token: string;
+	licenseUrl?: string,
+	licenseName?: string
 }
 
 export default function createAndMount(
 	config: Config,
 	messageRepo?: MessagesRepository,
-	dataRightsUrl: string,
-	dataRightsText: string,
 ): ComponentPublicInstance {
 	const app = createApp( App );
 	const store = initStore( config );

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,8 +10,8 @@ import MessagesRepository from './plugins/MessagesPlugin/MessagesRepository';
 interface Config {
 	rootSelector: string;
 	token: string;
-	licenseUrl?: string,
-	licenseName?: string
+	licenseUrl?: string;
+	licenseName?: string;
 }
 
 export default function createAndMount(

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,8 @@ interface Config {
 export default function createAndMount(
 	config: Config,
 	messageRepo?: MessagesRepository,
+	dataRightsUrl: string,
+	dataRightsText: string,
 ): ComponentPublicInstance {
 	const app = createApp( App );
 	const store = initStore( config );

--- a/src/plugins/MessagesPlugin/MessageKeys.ts
+++ b/src/plugins/MessagesPlugin/MessageKeys.ts
@@ -8,6 +8,7 @@ type MessageKeys
  | 'wikibaselexeme-newlexeme-submit'
  | 'wikibaselexeme-newlexeme-error-no-lemma'
  | 'wikibaselexeme-newlexeme-error-lemma-is-too-long'
- | 'wikibase-shortcopyrightwarning';
+ | 'wikibase-shortcopyrightwarning'
+ | 'copyrightpage';
 
 export default MessageKeys;

--- a/src/plugins/MessagesPlugin/MessageKeys.ts
+++ b/src/plugins/MessagesPlugin/MessageKeys.ts
@@ -7,6 +7,7 @@ type MessageKeys
  | 'wikibaselexeme-newlexeme-lexicalcategory-placeholder'
  | 'wikibaselexeme-newlexeme-submit'
  | 'wikibaselexeme-newlexeme-error-no-lemma'
- | 'wikibaselexeme-newlexeme-error-lemma-is-too-long';
+ | 'wikibaselexeme-newlexeme-error-lemma-is-too-long'
+ | 'wikibase-shortcopyrightwarning';
 
 export default MessageKeys;

--- a/src/plugins/MessagesPlugin/MockMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/MockMessagesRepository.ts
@@ -11,6 +11,8 @@ const messages: Record<MessageKeys, string> = {
 	'wikibaselexeme-newlexeme-submit': 'Create Lexeme',
 	'wikibaselexeme-newlexeme-error-no-lemma': 'Lemma field is empty, please make an entry.',
 	'wikibaselexeme-newlexeme-error-lemma-is-too-long': 'FIXME (copy is missing!)',
+	'wikibase-shortcopyrightwarning': 'By clicking "$1", you agree to the [[$2|terms of use]], and you irrevocably agree to release your contribution under the [$3 $4].',
+	copyrightpage: '{{ns:project}}:Copyrights',
 };
 
 export class MockMessagesRepository implements MessagesRepository {

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -3,4 +3,8 @@ export default interface RootState {
 	language: string;
 	lexicalCategory: string;
 	token: string;
+	config: {
+		licenseUrl: string;
+		licenseName: string;
+	}
 }

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -6,5 +6,5 @@ export default interface RootState {
 	config: {
 		licenseUrl: string;
 		licenseName: string;
-	}
+	};
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,9 +14,9 @@ import mutations from './mutations';
 import RootState from './RootState';
 
 interface StoreParams {
-	token?: string,
-	licenseUrl?: string,
-	licenseName?: string,
+	token?: string;
+	licenseUrl?: string;
+	licenseName?: string;
 }
 
 export default function initStore( {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -22,7 +22,7 @@ interface StoreParams {
 export default function initStore( {
 	token = '',
 	licenseUrl = '',
-	licenseName = ''
+	licenseName = '',
 }: StoreParams ): Store<RootState> {
 	return createStore( {
 		state(): RootState {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -16,7 +16,7 @@ import RootState from './RootState';
 interface StoreParams {
 	token?: string,
 	licenseUrl?: string,
-	licenseName?: string;
+	licenseName?: string,
 }
 
 export default function initStore( {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,11 +14,15 @@ import mutations from './mutations';
 import RootState from './RootState';
 
 interface StoreParams {
-	token?: string;
+	token?: string,
+	licenseUrl?: string,
+	licenseName?: string;
 }
 
 export default function initStore( {
 	token = '',
+	licenseUrl = '',
+	licenseName = ''
 }: StoreParams ): Store<RootState> {
 	return createStore( {
 		state(): RootState {
@@ -27,6 +31,10 @@ export default function initStore( {
 				language: '',
 				lexicalCategory: '',
 				token,
+				config: {
+					licenseUrl,
+					licenseName,
+				},
 			};
 		},
 		mutations,

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -2,7 +2,6 @@ import { mount } from '@vue/test-utils';
 import NewLexemeForm from '@/components/NewLexemeForm.vue';
 import initStore from '@/store';
 
-const store = initStore( {} );
 describe( 'NewLexemeForm', () => {
 	let store: ReturnType<typeof initStore>;
 	beforeEach( () => {

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -2,6 +2,7 @@ import { mount } from '@vue/test-utils';
 import NewLexemeForm from '@/components/NewLexemeForm.vue';
 import initStore from '@/store';
 
+const store = initStore( {} );
 describe( 'NewLexemeForm', () => {
 	let store: ReturnType<typeof initStore>;
 	beforeEach( () => {


### PR DESCRIPTION
While working on this it became apparent we are going to have to get some of the information from the RepoSettings in order to display the CC0 license link correctly. 
This PR reflects the new-lexeme-special-page side of receiving the parameters, initiating the store with them and using them within the component.

Bug: [T298152](https://phabricator.wikimedia.org/T298152)