### PR TITLE
Simplify wikit-vue-components CSS alias in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,10 +32,7 @@ export default defineConfig( {
 		alias: {
 			'vue': '@vue/compat',
 			'@vue/composition-api': '@vue/compat',
-			'@wmde/wikit-vue-components/dist/wikit-vue-components.css': resolve(
-				__dirname,
-				'node_modules/@wmde/wikit-vue-components/dist/wikit-vue-components.css',
-			),
+			'@wmde/wikit-vue-components/dist/wikit-vue-components.css': '@wmde/wikit-vue-components/dist/wikit-vue-components.css',
 			'@wmde/wikit-vue-components/src/styles/mixins/Typography': '@wmde/wikit-vue-components/src/styles/mixins/Typography',
 			'@wmde/wikit-vue-components': resolve(
 				__dirname,


### PR DESCRIPTION
Apparently this doesn’t actually need a `resolve()` call, it can just resolve to itself (just like `Typography` below) and that’s enough to exempt it from the overall `@wmde/wikit-vue-components` alias.