### PR TITLE
Allow passing state from createAndMount to store

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import {
 	ComponentPublicInstance,
 	createApp,
 } from 'vue';
-import store from './store';
+import initStore from './store';
 import App from './App.vue';
 import Messages, { MessagesKey } from './plugins/MessagesPlugin/Messages';
 import MessagesRepository from './plugins/MessagesPlugin/MessagesRepository';
@@ -16,6 +16,7 @@ export default function createAndMount(
 	messageRepo?: MessagesRepository,
 ): ComponentPublicInstance {
 	const app = createApp( App );
+	const store = initStore( config );
 	app.use( store );
 
 	app.provide( MessagesKey, new Messages( messageRepo ) );

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,20 +4,33 @@
  * @see https://vuex.vuejs.org/guide/structure.html
  */
 
-import { createStore } from 'vuex';
+import {
+	createStore,
+	Store,
+} from 'vuex';
 
 import actions from './actions';
 import mutations from './mutations';
 import RootState from './RootState';
 
-export default createStore( {
-	state(): RootState {
-		return {
-			lemma: '',
-			language: '',
-			lexicalCategory: '',
-		};
-	},
-	mutations,
-	actions,
-} );
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface StoreParams {
+	// param: Type;
+}
+
+// eslint-disable-next-line no-empty-pattern
+export default function initStore( {
+	// param = 'default',
+}: StoreParams ): Store<RootState> {
+	return createStore( {
+		state(): RootState {
+			return {
+				lemma: '',
+				language: '',
+				lexicalCategory: '',
+			};
+		},
+		mutations,
+		actions,
+	} );
+}

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -1,8 +1,10 @@
 import { mount } from '@vue/test-utils';
 import NewLexemeForm from '@/components/NewLexemeForm.vue';
-import store from '@/store';
+import initStore from '@/store';
 
 describe( 'NewLexemeForm', () => {
+	const store = initStore( {} );
+
 	function mountForm() {
 		return mount( NewLexemeForm, {
 			global: {


### PR DESCRIPTION
Instead of directly exporting a store instance, export a function to create the store, which can pass through some initial state. In this commit, we’re not actually defining any such state yet, but that will come soon, so we already use the interface / object-destructure syntax and temporarily silence the lints complaining about that.

Co-Authored-By: Noa wmde <noa.rave@wikimedia.de>
Co-Authored-By: Itamar Givon <itamar.givon@wikimedia.de>

---

Extracted from #47, since we’ll also want it for the [CSRF token](https://phabricator.wikimedia.org/T302001).