### PR TITLE
Add hidden token input to form

### DIFF
--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -38,6 +38,7 @@ const lexicalCategory = computed( {
 		store.commit( SET_LEXICAL_CATEGORY, newLexicalCategory );
 	},
 } );
+const token = computed( () => store.state.token );
 </script>
 
 <script lang="ts">
@@ -59,6 +60,11 @@ export default {
 		<lexical-category-input
 			v-model="lexicalCategory"
 		/>
+		<input
+			type="hidden"
+			name="wpEditToken"
+			:value="token"
+		>
 		<div>
 			<wikit-button
 				class="form-button-submit"

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,7 @@ import MessagesRepository from './plugins/MessagesPlugin/MessagesRepository';
 
 interface Config {
 	rootSelector: string;
+	token: string;
 }
 
 export default function createAndMount(

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -2,4 +2,5 @@ export default interface RootState {
 	lemma: string;
 	language: string;
 	lexicalCategory: string;
+	token: string;
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -13,14 +13,12 @@ import actions from './actions';
 import mutations from './mutations';
 import RootState from './RootState';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface StoreParams {
-	// param: Type;
+	token?: string;
 }
 
-// eslint-disable-next-line no-empty-pattern
 export default function initStore( {
-	// param = 'default',
+	token = '',
 }: StoreParams ): Store<RootState> {
 	return createStore( {
 		state(): RootState {
@@ -28,6 +26,7 @@ export default function initStore( {
 				lemma: '',
 				language: '',
 				lexicalCategory: '',
+				token,
 			};
 		},
 		mutations,

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -3,7 +3,10 @@ import NewLexemeForm from '@/components/NewLexemeForm.vue';
 import initStore from '@/store';
 
 describe( 'NewLexemeForm', () => {
-	const store = initStore( {} );
+	let store: ReturnType<typeof initStore>;
+	beforeEach( () => {
+		store = initStore( {} );
+	} );
 
 	function mountForm() {
 		return mount( NewLexemeForm, {
@@ -38,5 +41,16 @@ describe( 'NewLexemeForm', () => {
 		await lexicalCategoryInput.setValue( 'foo' );
 
 		expect( store.state.lexicalCategory ).toBe( 'foo' );
+	} );
+
+	it( 'has a hidden input with the edit token', async () => {
+		const token = 'edit token+\\';
+		store = initStore( { token } );
+		const wrapper = mountForm();
+
+		const tokenInput = wrapper.find( 'input[name=wpEditToken]' );
+
+		expect( tokenInput.attributes().value ).toBe( token );
+		expect( tokenInput.attributes().type ).toBe( 'hidden' );
 	} );
 } );

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -9,7 +9,10 @@ describe( 'createAndMount', () => {
 		const discardedElement = document.createElement( 'div' );
 		rootElement.append( discardedElement );
 
-		const instance = createAndMount( { rootSelector: '#test-app' } );
+		const instance = createAndMount( {
+			rootSelector: '#test-app',
+			token: 'test-token',
+		} );
 
 		expect( rootElement.firstChild ).toBe( instance.$el );
 		expect( discardedElement.parentElement ).toBe( null );


### PR DESCRIPTION
Using a token passed into `createAndMount()`.

Bug: T302001

---

This doesn’t include a test for `createAndMount` passing the token into the store, because I’m not sure how to test that. Should we test (again) that there’s an input with the right value? (But then `main.test.ts` probably belongs in `integration/` rather than `unit/`.)