### PR TITLE
Add lemma language input and submit form

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
 	"baseUrl": "http://localhost:3000/",
+	"chromeWebSecurity": false,
 	"supportFile": false
 }

--- a/cypress/integration/NewLexemeForm.spec.js
+++ b/cypress/integration/NewLexemeForm.spec.js
@@ -1,11 +1,32 @@
 describe( 'NewLexemeForm', () => {
 
-	it( 'adds a hidden input with the CSRF token', () => {
+	it( 'submits form data', () => {
 		cy.visit( '/' );
 
-		cy.get( 'input[name=wpEditToken]' )
-			.should( 'have.value', 'dev-token' )
-			.should( 'be.hidden' );
+		cy.intercept( 'POST', '/' )
+			.as( 'post' );
+
+		cy.get( 'input[name=lemma]' )
+			.type( 'test lemma' );
+
+		cy.get( 'input[name=lexeme-language]' )
+			.type( 'Q123' );
+
+		cy.get( 'input[name=lexicalcategory]' )
+			.type( 'Q456' );
+
+		cy.get( '.wbl-snl-form' )
+			.submit();
+
+		cy.wait( '@post' )
+			.then( ( { request } ) => {
+				const params = new URLSearchParams( request.body );
+				expect( params.get( 'lemma' ) ).to.equal( 'test lemma' );
+				expect( params.get( 'lemma-language' ) ).to.equal( 'en' );
+				expect( params.get( 'lexeme-language' ) ).to.equal( 'Q123' );
+				expect( params.get( 'lexicalcategory' ) ).to.equal( 'Q456' );
+				expect( params.get( 'wpEditToken' ) ).to.equal( 'dev-token' );
+			} );
 	} );
 
 } );

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,9 @@
 				"typescript": "^4.5.5",
 				"vite": "^2.7.13",
 				"vue-tsc": "^0.32.0"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
 		"url": "https://phabricator.wikimedia.org/project/board/5674/"
 	},
 	"homepage": "https://github.com/wmde/new-lexeme-special-page#readme",
+	"engines": {
+		"node": ">=16"
+	},
 	"dependencies": {
 		"@vue/compat": "^3.2.30",
 		"@wmde/wikit-tokens": "^2.1.0-alpha.12",

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -50,10 +50,15 @@ export default {
 </script>
 
 <template>
-	<form class="wbl-snl-form">
+	<form class="wbl-snl-form" method="post">
 		<lemma-input
 			v-model="lemma"
 		/>
+		<input
+			type="hidden"
+			name="lemma-language"
+			value="en"
+		>
 		<language-input
 			v-model="language"
 		/>
@@ -70,6 +75,7 @@ export default {
 				class="form-button-submit"
 				type="progressive"
 				variant="primary"
+				native-type="submit"
 			>
 				{{ $messages.get( 'wikibaselexeme-newlexeme-submit' ) }}
 			</wikit-button>


### PR DESCRIPTION
This is a temporary solution to make creating lexemes work, by targeting the noscript backend of the special page; we want to replace this with an API request later. (At some point the hard-coded lemma-language will also be replaced, of course.)

The previous simple Cypress test is replaced with one that watches for a form submit and checks the submitted data (including a token that we hard-code in index.html). Unfortunately, Chromium reports inexplicable cross-origin errors when submitting, blocking the iframe with origin http://localhost:3000 from accessing a cross-origin frame at http://localhost:3000, or something like that (yes, that’s the same host twice, as far as I can tell). I haven’t been able to find a solution for that, so for now, work around it by disabling Chrome web security in cypress.json. We can remove that line once we no longer submit the form.

Bug: T298153

---

See https://gerrit.wikimedia.org/r/c/mediawiki/extensions/WikibaseLexeme/+/763719 for the WikibaseLexeme part.