### PR TITLE
Remove vue-tsc from build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 	"main": "main.ts",
 	"scripts": {
 		"dev": "vite",
-		"build": "vue-tsc --noEmit && vite build",
+		"build": "vite build",
 		"buildPreview": "BUILD_AS_APP=1 vite build",
 		"fix": "run-s fix:*",
 		"fix:prettier": "prettier --write '**/*.{json,yml,yaml}'",


### PR DESCRIPTION
This command doesn’t actually contribute to the build results, it just takes a lot of time (much longer than `vite build` itself). We already run this as part of the test command, so I don’t think there’s a reason to keep it in the build command as well.