### PR TITLE
Update typescript-eslint packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
 			"devDependencies": {
 				"@rushstack/eslint-patch": "^1.1.0",
 				"@types/jest": "^27.4.0",
-				"@typescript-eslint/eslint-plugin": "^5.10.2",
-				"@typescript-eslint/parser": "^5.10.2",
+				"@typescript-eslint/eslint-plugin": "^5.14.0",
+				"@typescript-eslint/parser": "^5.14.0",
 				"@vitejs/plugin-vue": "^2.1.0",
 				"@vue/eslint-config-typescript": "^10.0.0",
 				"@vue/test-utils": "^2.0.0-rc.17",
@@ -1690,14 +1690,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
-			"integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
+			"integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/type-utils": "5.13.0",
-				"@typescript-eslint/utils": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/type-utils": "5.14.0",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -1738,14 +1738,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
-			"integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+			"integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/typescript-estree": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"debug": "^4.3.2"
 			},
 			"engines": {
@@ -1765,13 +1765,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
-			"integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+			"integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/visitor-keys": "5.13.0"
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1782,12 +1782,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
-			"integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
+			"integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/utils": "5.13.0",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			},
@@ -1808,9 +1808,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
-			"integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+			"integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1821,13 +1821,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
-			"integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+			"integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/visitor-keys": "5.13.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -1863,15 +1863,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
-			"integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
+			"integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
 			"dev": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/typescript-estree": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			},
@@ -1887,12 +1887,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
-			"integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+			"integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "5.13.0",
+				"@typescript-eslint/types": "5.14.0",
 				"eslint-visitor-keys": "^3.0.0"
 			},
 			"engines": {
@@ -14697,14 +14697,14 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.13.0.tgz",
-			"integrity": "sha512-vLktb2Uec81fxm/cfz2Hd6QaWOs8qdmVAZXLdOBX6JFJDhf6oDZpMzZ4/LZ6SFM/5DgDcxIMIvy3F+O9yZBuiQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
+			"integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/type-utils": "5.13.0",
-				"@typescript-eslint/utils": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/type-utils": "5.14.0",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"functional-red-black-tree": "^1.0.1",
 				"ignore": "^5.1.8",
@@ -14725,52 +14725,52 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.13.0.tgz",
-			"integrity": "sha512-GdrU4GvBE29tm2RqWOM0P5QfCtgCyN4hXICj/X9ibKED16136l9ZpoJvCL5pSKtmJzA+NRDzQ312wWMejCVVfg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+			"integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/typescript-estree": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"debug": "^4.3.2"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.13.0.tgz",
-			"integrity": "sha512-T4N8UvKYDSfVYdmJq7g2IPJYCRzwtp74KyDZytkR4OL3NRupvswvmJQJ4CX5tDSurW2cvCc1Ia1qM7d0jpa7IA==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+			"integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/visitor-keys": "5.13.0"
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.13.0.tgz",
-			"integrity": "sha512-/nz7qFizaBM1SuqAKb7GLkcNn2buRdDgZraXlkhz+vUGiN1NZ9LzkA595tHHeduAiS2MsHqMNhE2zNzGdw43Yg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
+			"integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/utils": "5.13.0",
+				"@typescript-eslint/utils": "5.14.0",
 				"debug": "^4.3.2",
 				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.13.0.tgz",
-			"integrity": "sha512-LmE/KO6DUy0nFY/OoQU0XelnmDt+V8lPQhh8MOVa7Y5k2gGRd6U9Kp3wAjhB4OHg57tUO0nOnwYQhRRyEAyOyg==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+			"integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.13.0.tgz",
-			"integrity": "sha512-Q9cQow0DeLjnp5DuEDjLZ6JIkwGx3oYZe+BfcNuw/POhtpcxMTy18Icl6BJqTSd+3ftsrfuVb7mNHRZf7xiaNA==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+			"integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/visitor-keys": "5.13.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/visitor-keys": "5.14.0",
 				"debug": "^4.3.2",
 				"globby": "^11.0.4",
 				"is-glob": "^4.0.3",
@@ -14790,26 +14790,26 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.13.0.tgz",
-			"integrity": "sha512-+9oHlPWYNl6AwwoEt5TQryEHwiKRVjz7Vk6kaBeD3/kwHE5YqTGHtm/JZY8Bo9ITOeKutFaXnBlMgSATMJALUQ==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
+			"integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
 			"dev": true,
 			"requires": {
 				"@types/json-schema": "^7.0.9",
-				"@typescript-eslint/scope-manager": "5.13.0",
-				"@typescript-eslint/types": "5.13.0",
-				"@typescript-eslint/typescript-estree": "5.13.0",
+				"@typescript-eslint/scope-manager": "5.14.0",
+				"@typescript-eslint/types": "5.14.0",
+				"@typescript-eslint/typescript-estree": "5.14.0",
 				"eslint-scope": "^5.1.1",
 				"eslint-utils": "^3.0.0"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "5.13.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.13.0.tgz",
-			"integrity": "sha512-HLKEAS/qA1V7d9EzcpLFykTePmOQqOFim8oCvhY3pZgQ8Hi38hYpHd9e5GN6nQBFQNecNhws5wkS9Y5XIO0s/g==",
+			"version": "5.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+			"integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "5.13.0",
+				"@typescript-eslint/types": "5.14.0",
 				"eslint-visitor-keys": "^3.0.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
 	"devDependencies": {
 		"@rushstack/eslint-patch": "^1.1.0",
 		"@types/jest": "^27.4.0",
-		"@typescript-eslint/eslint-plugin": "^5.10.2",
-		"@typescript-eslint/parser": "^5.10.2",
+		"@typescript-eslint/eslint-plugin": "^5.14.0",
+		"@typescript-eslint/parser": "^5.14.0",
 		"@vitejs/plugin-vue": "^2.1.0",
 		"@vue/eslint-config-typescript": "^10.0.0",
 		"@vue/test-utils": "^2.0.0-rc.17",


### PR DESCRIPTION
Avoids warnings of this sort:

> WARNING: You are currently running a version of TypeScript which is
> not officially supported by @typescript-eslint/typescript-estree.
>
> You may find that it works just fine, or you may not.
>
> SUPPORTED TYPESCRIPT VERSIONS: >=3.3.1 <4.6.0
>
> YOUR TYPESCRIPT VERSION: 4.6.2