### PR TITLE
Add init() entry point with MwMessagesRepository

### DIFF
--- a/src/@types/mediawiki.ts
+++ b/src/@types/mediawiki.ts
@@ -1,0 +1,9 @@
+export interface MwMessage {
+	text(): string;
+	parse(): string;
+}
+export type MwMessages = ( key: string, ...params: readonly ( string|HTMLElement )[] ) => MwMessage;
+
+export interface MediaWiki {
+	message: MwMessages;
+}

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,10 @@
+import createAndMount, { Config } from './main';
+import MwMessagesRepository from './mediawiki/MwMessagesRepository';
+import { MediaWiki } from './@types/mediawiki';
+import { ComponentPublicInstance } from 'vue';
+
+export default function init( config: Config, mw: MediaWiki ): ComponentPublicInstance {
+	const messagesRepository = new MwMessagesRepository( mw.message );
+
+	return createAndMount( config, messagesRepository );
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import App from './App.vue';
 import Messages, { MessagesKey } from './plugins/MessagesPlugin/Messages';
 import MessagesRepository from './plugins/MessagesPlugin/MessagesRepository';
 
-interface Config {
+export interface Config {
 	rootSelector: string;
 	token: string;
 	licenseUrl?: string;

--- a/src/mediawiki/MwMessagesRepository.ts
+++ b/src/mediawiki/MwMessagesRepository.ts
@@ -1,0 +1,19 @@
+import MessagesRepository from '@/plugins/MessagesPlugin/MessagesRepository';
+import { MwMessages } from '@/@types/mediawiki';
+
+export default class MwMessagesRepository implements MessagesRepository {
+
+	private mwMessages: MwMessages;
+
+	public constructor( mwMessages: MwMessages ) {
+		this.mwMessages = mwMessages;
+	}
+
+	public get( messageKey: string, ...params: readonly ( string|HTMLElement )[] ): string {
+		return this.mwMessages( messageKey, ...params ).parse();
+	}
+
+	public getText( messageKey: string, ...params: readonly string[] ): string {
+		return this.mwMessages( messageKey, ...params ).text();
+	}
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ function getBuildConfig( isAppBuild: bool ): BuildOptions {
 	return {
 		target: 'es2015',
 		lib: {
-			entry: resolve( __dirname, 'src/main.ts' ),
+			entry: resolve( __dirname, 'src/init.ts' ),
 			name: 'main',
 			fileName: ( format ) => `SpecialNewLexeme.${format}.js`,
 			formats: [ 'cjs' ],


### PR DESCRIPTION
WikibaseLexeme.git will no longer directly call `createAndMount()` (though that’s still used directly by the dev entry point and the Cypress tests), but instead the new `init()` function. This new entry point creates the MediaWiki-based `MessagesRepository` implementation, and will also create other MediaWiki-based service implementations later (whereas dev and tests might use different implementations).

Bug: T302961