### PR TITLE
Turn second createAndMount() param into services object

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,15 @@
 			import createAndMount from './src/main.ts';
 			import { MockMessagesRepository } from './src/plugins/MessagesPlugin/MockMessagesRepository';
 
-			createAndMount( { rootSelector: '#app', token: 'dev-token' }, new MockMessagesRepository() );
+			const config = {
+				rootSelector: '#app',
+				token: 'dev-token',
+			};
+			const services = {
+				messagesRepository: new MockMessagesRepository(),
+			};
+
+			createAndMount( config, services );
 		</script>
 	</body>
 </html>

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,10 +1,16 @@
-import createAndMount, { Config } from './main';
+import createAndMount, {
+	Config,
+	Services,
+} from './main';
 import MwMessagesRepository from './mediawiki/MwMessagesRepository';
 import { MediaWiki } from './@types/mediawiki';
 import { ComponentPublicInstance } from 'vue';
 
 export default function init( config: Config, mw: MediaWiki ): ComponentPublicInstance {
 	const messagesRepository = new MwMessagesRepository( mw.message );
+	const services: Services = {
+		messagesRepository,
+	};
 
-	return createAndMount( config, messagesRepository );
+	return createAndMount( config, services );
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,15 +14,19 @@ export interface Config {
 	licenseName?: string;
 }
 
+export interface Services {
+	messagesRepository?: MessagesRepository;
+}
+
 export default function createAndMount(
 	config: Config,
-	messageRepo?: MessagesRepository,
+	services: Services,
 ): ComponentPublicInstance {
 	const app = createApp( App );
 	const store = initStore( config );
 	app.use( store );
 
-	app.provide( MessagesKey, new Messages( messageRepo ) );
+	app.provide( MessagesKey, new Messages( services.messagesRepository ) );
 
 	return app.mount( config.rootSelector );
 }

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -12,7 +12,7 @@ describe( 'createAndMount', () => {
 		const instance = createAndMount( {
 			rootSelector: '#test-app',
 			token: 'test-token',
-		} );
+		}, {} );
 
 		expect( rootElement.firstChild ).toBe( instance.$el );
 		expect( discardedElement.parentElement ).toBe( null );


### PR DESCRIPTION
We’ll need more than one service soon, so let’s turn this into a container of possibly several services. The `messagesRepository` service remains optional for now, but the whole `services` object is required, even if it’s just the empty object. (I’m not yet sure if additional services will also be optional or required.)

Bug: T302961