### PR TITLE
Add back compatConfig blocks

### DIFF
--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -13,6 +13,14 @@ defineEmits( [ 'update:modelValue' ] );
 const messages = useMessages();
 </script>
 
+<script lang="ts">
+export default {
+	compatConfig: {
+		MODE: 3,
+	},
+};
+</script>
+
 <template>
 	<text-input
 		class="wbl-snl-language-input"

--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -30,6 +30,14 @@ function buildError( errorKey: Props['error'] ) {
 }
 </script>
 
+<script lang="ts">
+export default {
+	compatConfig: {
+		MODE: 3,
+	},
+};
+</script>
+
 <template>
 	<text-input
 		class="wbl-snl-lemma-input"

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -13,6 +13,14 @@ defineEmits( [ 'update:modelValue' ] );
 const messages = useMessages();
 </script>
 
+<script lang="ts">
+export default {
+	compatConfig: {
+		MODE: 3,
+	},
+};
+</script>
+
 <template>
 	<text-input
 		class="wbl-snl-lexical-category-input"

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -50,6 +50,14 @@ const copyrightText = $messages.get(
 );
 </script>
 
+<script lang="ts">
+export default {
+	compatConfig: {
+		MODE: 3,
+	},
+};
+</script>
+
 <template>
 	<form class="wbl-snl-form" method="post">
 		<lemma-input


### PR DESCRIPTION
It turns out we still need those while running under the migration build.