### PR TITLE
Remove hidden token input from NewLexemeForm

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
 
 			const config = {
 				rootSelector: '#app',
-				token: 'dev-token',
 			};
 			const services = {
 				messagesRepository: new MockMessagesRepository(),

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -39,7 +39,6 @@ const lexicalCategory = computed( {
 		store.commit( SET_LEXICAL_CATEGORY, newLexicalCategory );
 	},
 } );
-const token = computed( () => store.state.token );
 const submitMsg = $messages.get( 'wikibaselexeme-newlexeme-submit' );
 const termsOfUseTitle = $messages.get( 'copyrightpage' );
 const copyrightText = $messages.get(
@@ -80,11 +79,6 @@ export default {
 		<lexical-category-input
 			v-model="lexicalCategory"
 		/>
-		<input
-			type="hidden"
-			name="wpEditToken"
-			:value="token"
-		>
 		<!-- eslint-disable-next-line vue/no-v-html -->
 		<p class="wbl-snl-copyright" v-html="copyrightText" />
 		<div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,6 @@ import MessagesRepository from './plugins/MessagesPlugin/MessagesRepository';
 
 export interface Config {
 	rootSelector: string;
-	token: string;
 	licenseUrl?: string;
 	licenseName?: string;
 }

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -2,7 +2,6 @@ export default interface RootState {
 	lemma: string;
 	language: string;
 	lexicalCategory: string;
-	token: string;
 	config: {
 		licenseUrl: string;
 		licenseName: string;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -15,7 +15,6 @@ import mutations from './mutations';
 import RootState from './RootState';
 
 interface StoreParams {
-	token?: string;
 	licenseUrl?: string;
 	licenseName?: string;
 }
@@ -26,7 +25,6 @@ interface StoreServices {
 
 export default function initStore(
 	{
-		token = '',
 		licenseUrl = '',
 		licenseName = '',
 	}: StoreParams,
@@ -40,7 +38,6 @@ export default function initStore(
 				lemma: '',
 				language: '',
 				lexicalCategory: '',
-				token,
 				config: {
 					licenseUrl,
 					licenseName,

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -43,15 +43,4 @@ describe( 'NewLexemeForm', () => {
 
 		expect( store.state.lexicalCategory ).toBe( 'foo' );
 	} );
-
-	it( 'has a hidden input with the edit token', async () => {
-		const token = 'edit token+\\';
-		store = initStore( { token }, { lexemeCreator: unusedLexemeCreator } );
-		const wrapper = mountForm();
-
-		const tokenInput = wrapper.find( 'input[name=wpEditToken]' );
-
-		expect( tokenInput.attributes().value ).toBe( token );
-		expect( tokenInput.attributes().type ).toBe( 'hidden' );
-	} );
 } );

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -12,7 +12,6 @@ describe( 'createAndMount', () => {
 
 		const instance = createAndMount( {
 			rootSelector: '#test-app',
-			token: 'test-token',
 		}, { lexemeCreator: unusedLexemeCreator } );
 
 		expect( rootElement.firstChild ).toBe( instance.$el );


### PR DESCRIPTION
No longer needed now that we’re using the API to create lexemes, `postWithEditToken()` adds the token automatically.

Bug: T302961