### PR TITLE
Pass tags into MwApiLexemeCreator

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -7,9 +7,13 @@ import MwMessagesRepository from './mediawiki/MwMessagesRepository';
 import { MediaWiki } from './@types/mediawiki';
 import { ComponentPublicInstance } from 'vue';
 
-export default function init( config: Config, mw: MediaWiki ): ComponentPublicInstance {
+interface InitConfig extends Config {
+	tags: string[];
+}
+
+export default function init( config: InitConfig, mw: MediaWiki ): ComponentPublicInstance {
 	const messagesRepository = new MwMessagesRepository( mw.message );
-	const lexemeCreator = new MwApiLexemeCreator( new mw.Api() );
+	const lexemeCreator = new MwApiLexemeCreator( new mw.Api(), config.tags );
 	const services: Services = {
 		messagesRepository,
 		lexemeCreator,


### PR DESCRIPTION
`init()` now expects tags as part of its config, which are used when creating a new lexeme.

Bug: T302961

---

WikibaseLexeme counterpart: https://gerrit.wikimedia.org/r/c/mediawiki/extensions/WikibaseLexeme/+/771371