### PR TITLE
Add default parameters to mw.Api()

### DIFF
--- a/src/@types/mediawiki.ts
+++ b/src/@types/mediawiki.ts
@@ -9,7 +9,16 @@ export interface MwApi {
 	postWithEditToken( params: object ): Promise<unknown>;
 }
 
+interface MwApiOptions {
+	parameters?: object;
+}
+
+interface MwConfig {
+	get( key: string ): unknown;
+}
+
 export interface MediaWiki {
+	config: MwConfig;
 	message: MwMessages;
-	Api: new() => MwApi;
+	Api: new( defaultOptions?: MwApiOptions ) => MwApi;
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -12,8 +12,17 @@ interface InitConfig extends Config {
 }
 
 export default function init( config: InitConfig, mw: MediaWiki ): ComponentPublicInstance {
+	const languageCode = mw.config.get( 'wgUserLanguage' ) as string;
+	const api = new mw.Api( {
+		parameters: {
+			formatversion: 2,
+			uselang: languageCode,
+			errorformat: 'html',
+		},
+	} );
+
 	const messagesRepository = new MwMessagesRepository( mw.message );
-	const lexemeCreator = new MwApiLexemeCreator( new mw.Api(), config.tags );
+	const lexemeCreator = new MwApiLexemeCreator( api, config.tags );
 	const services: Services = {
 		messagesRepository,
 		lexemeCreator,


### PR DESCRIPTION
We want to make sure that the API uses the current user interface language, even if that was only set via `?uselang=` and isn’t in the user’s session, and also want to use the modern result format. Also, let’s set the error format already, though for now this is mostly a guess since we haven’t implemented error handling yet.