### PR TITLE
Fix double escape

### DIFF
--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -104,7 +104,7 @@ const messages = useMessages();
 		@input="onOptionSelected"
 	>
 		<template #no-results>
-			{{ messages.get( 'wikibaselexeme-newlexeme-no-results' ) }}
+			{{ messages.getUnescaped( 'wikibaselexeme-newlexeme-no-results' ) }}
 		</template>
 	</wikit-lookup>
 </template>

--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -29,8 +29,8 @@ export default {
 <template>
 	<div class="wbl-snl-language-lookup">
 		<item-lookup
-			:label="messages.get( 'wikibaselexeme-newlexeme-language' )"
-			:placeholder="messages.get( 'wikibaselexeme-newlexeme-language-placeholder' )"
+			:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-language' )"
+			:placeholder="messages.getUnescaped( 'wikibaselexeme-newlexeme-language-placeholder' )"
 			:value="modelValue"
 			:search-for-items="searchForItems"
 			@update:model-value="$emit( 'update:modelValue', $event )"

--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -17,13 +17,13 @@ function buildError( errorKey: Props['error'] ) {
 	if ( errorKey === 'ERROR_LEMMA_TOO_LONG' ) {
 		return {
 			type: 'error',
-			message: messages.get( 'wikibaselexeme-newlexeme-error-lemma-is-too-long' ),
+			message: messages.getUnescaped( 'wikibaselexeme-newlexeme-error-lemma-is-too-long' ),
 		};
 	}
 	if ( errorKey === 'ERROR_NO_LEMMA' ) {
 		return {
 			type: 'error',
-			message: messages.get( 'wikibaselexeme-newlexeme-error-no-lemma' ),
+			message: messages.getUnescaped( 'wikibaselexeme-newlexeme-error-no-lemma' ),
 		};
 	}
 	return null;
@@ -41,8 +41,8 @@ export default {
 <template>
 	<text-input
 		class="wbl-snl-lemma-input"
-		:label="messages.get( 'wikibaselexeme-newlexeme-lemma' )"
-		:placeholder="messages.get( 'wikibaselexeme-newlexeme-lemma-placeholder' )"
+		:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-lemma' )"
+		:placeholder="messages.getUnescaped( 'wikibaselexeme-newlexeme-lemma-placeholder' )"
 		name="lemma"
 		required
 		:error="buildError( error )"

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -24,8 +24,10 @@ export default {
 <template>
 	<text-input
 		class="wbl-snl-lexical-category-input"
-		:label="messages.get( 'wikibaselexeme-newlexeme-lexicalcategory' )"
-		:placeholder="messages.get( 'wikibaselexeme-newlexeme-lexicalcategory-placeholder' )"
+		:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-lexicalcategory' )"
+		:placeholder="messages.getUnescaped(
+			'wikibaselexeme-newlexeme-lexicalcategory-placeholder'
+		)"
 		name="lexicalcategory"
 		required
 		pattern="Q[1-9][0-9]*"

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -39,7 +39,7 @@ const lexicalCategory = computed( {
 		store.commit( SET_LEXICAL_CATEGORY, newLexicalCategory );
 	},
 } );
-const submitMsg = $messages.get( 'wikibaselexeme-newlexeme-submit' );
+const submitMsg = $messages.getUnescaped( 'wikibaselexeme-newlexeme-submit' );
 const termsOfUseTitle = $messages.get( 'copyrightpage' );
 const copyrightText = $messages.get(
 	'wikibase-shortcopyrightwarning',

--- a/src/plugins/MessagesPlugin/DevMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/DevMessagesRepository.ts
@@ -20,9 +20,16 @@ const messages: Record<MessageKeys, string> = {
 export default class DevMessagesRepository implements MessagesRepository {
 
 	public get( key: MessageKeys ): string {
-		return messages[ key ] !== undefined ? messages[ key ] : `⧼${key}⧽`;
+		return messages[ key ] !== undefined ? this.escape( messages[ key ] ) : `⧼${key}⧽`;
 	}
 	public getText( key: MessageKeys ): string {
 		return messages[ key ] !== undefined ? messages[ key ] : `⧼${key}⧽`;
+	}
+
+	private escape( s: string ) {
+		return s.replace(
+			/[^0-9A-Za-z,.: ]/g,
+			( c ) => '&#' + c.charCodeAt( 0 ) + ';',
+		);
 	}
 }


### PR DESCRIPTION
Vue escapes by default the text it displays, therefore we must not give it already escaped text.

The dev message repository has been adjusted to better mimic what the mediawiki mw.messages API does.