### PR TITLE
Move config from store to plugin

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,8 @@
 
 			const config = {
 				rootSelector: '#app',
+				licenseUrl: '',
+				licenseName: '',
 			};
 			const services = {
 				itemSearcher: new DevItemSearcher(),

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -3,6 +3,7 @@ import { CREATE_LEXEME } from '@/store/actions';
 import { computed } from 'vue';
 import { useStore } from 'vuex';
 import { Button as WikitButton } from '@wmde/wikit-vue-components';
+import { useConfig } from '@/plugins/ConfigPlugin/Config';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import LemmaInput from '@/components/LemmaInput.vue';
 import LanguageInput from '@/components/LanguageInput.vue';
@@ -14,6 +15,7 @@ import {
 } from '@/store/mutations';
 import { useWikiRouter } from '@/plugins/WikiRouterPlugin/WikiRouter';
 
+const config = useConfig();
 const $messages = useMessages();
 const store = useStore();
 const lemma = computed( {
@@ -46,8 +48,8 @@ const copyrightText = $messages.get(
 	'wikibase-shortcopyrightwarning',
 	submitMsg,
 	termsOfUseTitle,
-	store.state.config.licenseUrl,
-	store.state.config.licenseName,
+	config.licenseUrl,
+	config.licenseName,
 );
 
 const wikiRouter = useWikiRouter();

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,6 +1,6 @@
 import MwApiItemSearcher from '@/data-access/MwApiItemSearcher';
 import createAndMount, {
-	Config,
+	CreateAndMountConfig,
 	Services,
 } from './main';
 import MwApiLexemeCreator from './data-access/MwApiLexemeCreator';
@@ -9,7 +9,7 @@ import { MediaWiki } from './@types/mediawiki';
 import { ComponentPublicInstance } from 'vue';
 import MediaWikiRouter from './plugins/WikiRouterPlugin/MediaWikiRouter';
 
-interface InitConfig extends Config {
+interface InitConfig extends CreateAndMountConfig {
 	tags: string[];
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import ItemSearcher from '@/data-access/ItemSearcher';
 import LexemeCreator from '@/data-access/LexemeCreator';
 import { ItemSearchKey } from '@/plugins/ItemSearchPlugin/ItemSearch';
+import { Config, ConfigKey } from '@/plugins/ConfigPlugin/Config';
 import {
 	ComponentPublicInstance,
 	createApp,
@@ -12,10 +13,8 @@ import MessagesRepository from './plugins/MessagesPlugin/MessagesRepository';
 import { WikiRouterKey } from './plugins/WikiRouterPlugin/WikiRouter';
 import WikiRouter from './plugins/WikiRouterPlugin/WikiRouter';
 
-export interface Config {
+export interface CreateAndMountConfig extends Config {
 	rootSelector: string;
-	licenseUrl?: string;
-	licenseName?: string;
 }
 
 export interface Services {
@@ -26,13 +25,14 @@ export interface Services {
 }
 
 export default function createAndMount(
-	config: Config,
+	config: CreateAndMountConfig,
 	services: Services,
 ): ComponentPublicInstance {
 	const app = createApp( App );
-	const store = initStore( config, services );
+	const store = initStore( services );
 	app.use( store );
 
+	app.provide( ConfigKey, config );
 	app.provide( MessagesKey, new Messages( services.messagesRepository ) );
 	app.provide( ItemSearchKey, services.itemSearcher );
 	app.provide( WikiRouterKey, services.wikiRouter );

--- a/src/plugins/ConfigPlugin/Config.ts
+++ b/src/plugins/ConfigPlugin/Config.ts
@@ -1,0 +1,17 @@
+import {
+	inject,
+	InjectionKey,
+} from 'vue';
+
+export interface Config {
+	readonly licenseUrl: string;
+	readonly licenseName: string;
+}
+
+export const ConfigKey: InjectionKey<Config> = Symbol( 'Config' );
+
+export function useConfig(): Config {
+	return inject( ConfigKey, () => {
+		throw new Error( 'No Config provided!' );
+	}, true );
+}

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -2,8 +2,4 @@ export default interface RootState {
 	lemma: string;
 	language: string;
 	lexicalCategory: string;
-	config: {
-		licenseUrl: string;
-		licenseName: string;
-	};
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -14,34 +14,19 @@ import createActions from './actions';
 import mutations from './mutations';
 import RootState from './RootState';
 
-interface StoreParams {
-	licenseUrl?: string;
-	licenseName?: string;
-}
-
 interface StoreServices {
 	lexemeCreator: LexemeCreator;
 }
 
-export default function initStore(
-	{
-		licenseUrl = '',
-		licenseName = '',
-	}: StoreParams,
-	{
-		lexemeCreator,
-	}: StoreServices,
-): Store<RootState> {
+export default function initStore( {
+	lexemeCreator,
+}: StoreServices ): Store<RootState> {
 	return createStore( {
 		state(): RootState {
 			return {
 				lemma: '',
 				language: '',
 				lexicalCategory: '',
-				config: {
-					licenseUrl,
-					licenseName,
-				},
 			};
 		},
 		mutations,

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -1,3 +1,4 @@
+import { ConfigKey } from '@/plugins/ConfigPlugin/Config';
 import { mount } from '@vue/test-utils';
 import NewLexemeForm from '@/components/NewLexemeForm.vue';
 import initStore from '@/store';
@@ -11,7 +12,7 @@ jest.mock( 'lodash/debounce', () => jest.fn( ( fn ) => fn ) );
 describe( 'NewLexemeForm', () => {
 	let store: ReturnType<typeof initStore>;
 	beforeEach( () => {
-		store = initStore( {}, { lexemeCreator: unusedLexemeCreator } );
+		store = initStore( { lexemeCreator: unusedLexemeCreator } );
 	} );
 
 	function mountForm() {
@@ -19,6 +20,7 @@ describe( 'NewLexemeForm', () => {
 			global: {
 				plugins: [ store ],
 				provide: {
+					[ ConfigKey as symbol ]: {},
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ WikiRouterKey as symbol ]: null,
 				},
@@ -57,11 +59,12 @@ describe( 'NewLexemeForm', () => {
 	it( 'calls the API to create the Lexeme and then redirects to it', async () => {
 		const createLexeme = jest.fn().mockReturnValue( 'L123' );
 		const goToTitle = jest.fn();
-		const testStore = initStore( {}, { lexemeCreator: { createLexeme } } );
+		const testStore = initStore( { lexemeCreator: { createLexeme } } );
 		const wrapper = mount( NewLexemeForm, {
 			global: {
 				plugins: [ testStore ],
 				provide: {
+					[ ConfigKey as symbol ]: {},
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ WikiRouterKey as symbol ]: { goToTitle },
 				},

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -14,6 +14,8 @@ describe( 'createAndMount', () => {
 
 		const instance = createAndMount( {
 			rootSelector: '#test-app',
+			licenseUrl: '',
+			licenseName: '',
 		}, {
 			itemSearcher: unusedItemSearcher,
 			lexemeCreator: unusedLexemeCreator,


### PR DESCRIPTION
The config isn’t mutable state, so it doesn’t really belong in the store. A plugin that components can use directly seems to make more sense. (Mark the members of the new `Config` interface `readonly` to highlight that they’re not mutable.)

Bug: T303050