### PR TITLE
Fix Lookup keyboard scrolling onwiki

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,14 @@ import { Message as WikitMessage } from '@wmde/wikit-vue-components';
 import '@wmde/wikit-vue-components/dist/wikit-vue-components.css';
 </script>
 
+<script lang="ts">
+export default {
+	compatConfig: {
+		MODE: 3,
+	},
+};
+</script>
+
 <template>
 	<p class="wbl-snl-intro-text">
 		To Be Done

--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -92,6 +92,14 @@ function searchResultToMonolingualOption( searchResult: SearchedItemOption ): Mo
 const messages = useMessages();
 </script>
 
+<script lang="ts">
+export default {
+	compatConfig: {
+		MODE: 3,
+	},
+};
+</script>
+
 <template>
 	<wikit-lookup
 		:label="label"


### PR DESCRIPTION
For some reason, scrolling in the lookups with the Keyboard is broken when our app actually runs on mediawiki, but it works fine when it runs as a standalone on Netlify. I'm not yet sure about the cause.