### PR TITLE
add submit error message to Message pipeline and the Form component

### DIFF
--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -60,7 +60,7 @@ const error = computed( () => {
 			return firstError.message;
 		}
 
-		return 'TODO - generic error message';
+		return $messages.getUnescaped( 'wikibaselexeme-newlexeme-submit-error' );
 	}
 
 	return null;

--- a/src/plugins/MessagesPlugin/DevMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/DevMessagesRepository.ts
@@ -9,6 +9,7 @@ const messages: Record<MessageKeys, string> = {
 	'wikibaselexeme-newlexeme-lexicalcategory': 'Lexical category',
 	'wikibaselexeme-newlexeme-lexicalcategory-placeholder': 'The Lexeme\'s category, e.g. \'numeral\'',
 	'wikibaselexeme-newlexeme-submit': 'Create Lexeme',
+	'wikibaselexeme-newlexeme-submit-error': 'The server encountered a temporary error and could not complete your request. Please try again.',
 	'wikibaselexeme-newlexeme-error-no-lemma': 'Lemma field is empty, please make an entry.',
 	'wikibaselexeme-newlexeme-error-lemma-is-too-long': 'FIXME (copy is missing!)',
 	'wikibaselexeme-newlexeme-no-results': 'FIXME (copy is missing!)',

--- a/src/plugins/MessagesPlugin/MessageKeys.ts
+++ b/src/plugins/MessagesPlugin/MessageKeys.ts
@@ -6,6 +6,7 @@ type MessageKeys
  | 'wikibaselexeme-newlexeme-lexicalcategory'
  | 'wikibaselexeme-newlexeme-lexicalcategory-placeholder'
  | 'wikibaselexeme-newlexeme-submit'
+ | 'wikibaselexeme-newlexeme-submit-error'
  | 'wikibaselexeme-newlexeme-error-no-lemma'
  | 'wikibaselexeme-newlexeme-error-lemma-is-too-long'
  | 'wikibaselexeme-newlexeme-no-results'


### PR DESCRIPTION
This adds the `wikibaselexeme-newlexeme-submit-error `message key to the message repository and uses it in `NewLexemeForm.vue`.

Bug: T304490