### PR TITLE
Add linting for BEM-style classes in scss

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,17 +4,15 @@
 		"stylelint-config-standard-scss",
 		"stylelint-config-recommended-vue/scss"
 	],
-	"plugins": ["stylelint-use-logical-spec"],
+	"plugins": ["stylelint-use-logical-spec", "@namics/stylelint-bem"],
 	"rules": {
+		"plugin/stylelint-bem-namics": {
+			"patternPrefixes": [],
+			"helperPrefixes": [],
+			"namespaces": ["wbl-snl-"]
+		},
 		"indentation": "tab",
 		"selector-max-id": 1,
-		"liberty/use-logical-spec": true,
-		"selector-class-pattern": [
-			"^wbl-snl-[-_a-z0-9]+$",
-			{
-				"resolveNestedSelectors": true,
-				"message": "Selector class names should be lowercase and prefixed with wbl-snl-*."
-			}
-		]
+		"liberty/use-logical-spec": true
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 				"vuex": "^4.0.2"
 			},
 			"devDependencies": {
+				"@namics/stylelint-bem": "^7.0.0",
 				"@rushstack/eslint-patch": "^1.1.0",
 				"@types/jest": "^27.4.0",
 				"@types/lodash": "^4.14.180",
@@ -1388,6 +1389,22 @@
 			"integrity": "sha512-pndsgd4jXIGcgWKPXkN5AL1rdwhgQpLXWyK25jb42SUaeujs/GhRK8+Q4W97RTiCirf/DoaahcTI/3Op6+/gfw==",
 			"dev": true
 		},
+		"node_modules/@namics/stylelint-bem": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@namics/stylelint-bem/-/stylelint-bem-7.0.0.tgz",
+			"integrity": "sha512-XimlWZbCotBQbwB5YwcB5d7HNhoY4YBWyfoMbDcEuUWOCEmXDbfwsSDJR+cytm+/Z+lDVRnHd+iM01AaF0+R4A==",
+			"dev": true,
+			"dependencies": {
+				"css-selector-classes": "0.1.2",
+				"postcss-resolve-nested-selector": "0.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"stylelint": ">=7.0.0 <15.0.0"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2392,6 +2409,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -3374,6 +3400,28 @@
 				"readable-stream": ">=1.0.33-1 <1.1.0-0",
 				"xtend": ">=4.0.0 <4.1.0-0"
 			}
+		},
+		"node_modules/css-selector-classes": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/css-selector-classes/-/css-selector-classes-0.1.2.tgz",
+			"integrity": "sha1-JAPY5WAQHIKcXx35MIAyp6Qfw3Y=",
+			"dev": true,
+			"dependencies": {
+				"array-uniq": "^1.0.2",
+				"css-selector-parser": "~1.0.3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/css-selector-parser": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.0.4.tgz",
+			"integrity": "sha1-Zd/mFL1f0XW2Sgo/GTuHD8V5B3M=",
+			"dev": true,
+			"engines": [
+				"node >= 0.4.0"
+			]
 		},
 		"node_modules/css-tokenize": {
 			"version": "1.0.1",
@@ -14058,6 +14106,16 @@
 			"integrity": "sha512-pndsgd4jXIGcgWKPXkN5AL1rdwhgQpLXWyK25jb42SUaeujs/GhRK8+Q4W97RTiCirf/DoaahcTI/3Op6+/gfw==",
 			"dev": true
 		},
+		"@namics/stylelint-bem": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@namics/stylelint-bem/-/stylelint-bem-7.0.0.tgz",
+			"integrity": "sha512-XimlWZbCotBQbwB5YwcB5d7HNhoY4YBWyfoMbDcEuUWOCEmXDbfwsSDJR+cytm+/Z+lDVRnHd+iM01AaF0+R4A==",
+			"dev": true,
+			"requires": {
+				"css-selector-classes": "0.1.2",
+				"postcss-resolve-nested-selector": "0.1.1"
+			}
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -14849,6 +14907,12 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
+		"array-uniq": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+			"dev": true
+		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -15596,6 +15660,22 @@
 					}
 				}
 			}
+		},
+		"css-selector-classes": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/css-selector-classes/-/css-selector-classes-0.1.2.tgz",
+			"integrity": "sha1-JAPY5WAQHIKcXx35MIAyp6Qfw3Y=",
+			"dev": true,
+			"requires": {
+				"array-uniq": "^1.0.2",
+				"css-selector-parser": "~1.0.3"
+			}
+		},
+		"css-selector-parser": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.0.4.tgz",
+			"integrity": "sha1-Zd/mFL1f0XW2Sgo/GTuHD8V5B3M=",
+			"dev": true
 		},
 		"css-tokenize": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"vuex": "^4.0.2"
 	},
 	"devDependencies": {
+		"@namics/stylelint-bem": "^7.0.0",
 		"@rushstack/eslint-patch": "^1.1.0",
 		"@types/jest": "^27.4.0",
 		"@types/lodash": "^4.14.180",


### PR DESCRIPTION
This effectively extends the functionality of the selector-class-pattern
rule, and so that rule can be dropped from the configuration.

From the other rule-sets mentioned in T301694,
stylelint-selector-bem-pattern has much more complex configuration for
little apparent benefit. And Vue-BEM adds a new custom directive that
also seems like too much complexity for what little of a problem we here
have.

Thus, this uses https://github.com/merkle-open/stylelint-bem

Bug: T301694