### PR TITLE
PoC: Provide static HTML for info message

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
 	"main": "main.ts",
 	"scripts": {
 		"dev": "vite",
-		"build": "vite build",
-		"buildPreview": "BUILD_AS_APP=1 vite build",
+		"build": "BUILD_TYPE=info vite build && node render-info.js && vite build --emptyOutDir=false",
+		"buildPreview": "BUILD_TYPE=preview vite build",
 		"fix": "run-s fix:*",
 		"fix:prettier": "prettier --write '**/*.{json,yml,yaml}'",
 		"fix:eslint": "eslint --fix --ext .js,.ts,.vue --ignore-path .gitignore .",

--- a/render-info.js
+++ b/render-info.js
@@ -1,0 +1,9 @@
+const { open } = require( 'fs/promises' );
+const { createSSRApp } = require( 'vue' );
+const { pipeToNodeWritable } = require( 'vue/server-renderer' );
+const InfoMessage = require( './dist/info.cjs' );
+
+const app = createSSRApp( InfoMessage );
+open( 'dist/info.html', 'w' ).then( ( file ) => {
+	pipeToNodeWritable( app, {}, file.createWriteStream() );
+} );

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,9 @@
 import InfoMessage from '@/components/InfoMessage.vue';
 import NewLexemeForm from '@/components/NewLexemeForm.vue';
 import '@wmde/wikit-vue-components/dist/wikit-vue-components.css';
+import { inject } from 'vue';
+
+const infoHtml: string|undefined = inject( 'infoHtml', undefined );
 </script>
 
 <template>
@@ -10,7 +13,8 @@ import '@wmde/wikit-vue-components/dist/wikit-vue-components.css';
 	</p>
 	<div class="wbl-snl-app">
 		<new-lexeme-form />
-		<info-message />
+		<div v-if="infoHtml" v-html="infoHtml" />
+		<div v-else><info-message /></div>
 	</div>
 </template>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import InfoMessage from '@/components/InfoMessage.vue';
 import NewLexemeForm from '@/components/NewLexemeForm.vue';
-import { Message as WikitMessage } from '@wmde/wikit-vue-components';
 import '@wmde/wikit-vue-components/dist/wikit-vue-components.css';
 </script>
 
@@ -10,9 +10,7 @@ import '@wmde/wikit-vue-components/dist/wikit-vue-components.css';
 	</p>
 	<div class="wbl-snl-app">
 		<new-lexeme-form />
-		<wikit-message type="notice">
-			To Be Done
-		</wikit-message>
+		<info-message />
 	</div>
 </template>
 

--- a/src/components/InfoMessage.vue
+++ b/src/components/InfoMessage.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { Icon as WikitIcon } from '@wmde/wikit-vue-components';
+</script>
+
+<template>
+	<div class="wbl-snl-info-message">
+		<p class="wbl-snl-info-message__about">
+			<wikit-icon type="info" />
+			ABOUT_LEXEMES
+		</p>
+		<p>LEXICOGRAPHICAL_DATA</p>
+		<div class="wbl-snl-info-message__example">
+			(LEXEME_ID)
+			<div>
+				<span
+					lang="LEMMA_LANGUAGE"
+					class="wbl-snl-info-message__example-lemma"
+				>
+					LEMMA_TEXT
+				</span>
+				LEMMA_LANGUAGE
+			</div>
+			<div>
+				LANGUAGE_COLON<!---->LANGUAGE_LINK
+				LEXICAL_CATEGORY_COLON<!---->LEXICAL_CATEGORY_LINK
+			</div>
+		</div>
+		<p>NO_GENERAL_DATA</p>
+	</div>
+</template>
+
+<style lang="scss">
+@import "@wmde/wikit-tokens/variables";
+
+.wbl-snl-info-message {
+	border-style: $border-style-base;
+	border-width: $border-width-thin;
+	border-radius: $border-radius-base;
+	border-color: $border-color-base-subtle;
+	background-color: $background-color-base-default;
+	padding: $dimension-layout-small;
+
+	& > :not(:first-child) {
+		margin-block-start: $dimension-layout-xsmall;
+	}
+
+	&__example {
+		display: flex;
+		flex-direction: row;
+
+		&-lemma {
+			font-weight: bold;
+		}
+	}
+}
+</style>

--- a/src/components/InfoMessage.vue
+++ b/src/components/InfoMessage.vue
@@ -39,6 +39,8 @@ import { Icon as WikitIcon } from '@wmde/wikit-vue-components';
 	border-color: $border-color-base-subtle;
 	background-color: $background-color-base-default;
 	padding: $dimension-layout-small;
+	block-size: 100%;
+	box-sizing: border-box;
 
 	& > :not(:first-child) {
 		margin-block-start: $dimension-layout-xsmall;

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import WikiRouter from './plugins/WikiRouterPlugin/WikiRouter';
 
 export interface CreateAndMountConfig extends Config {
 	rootSelector: string;
+	infoHtml?: string;
 }
 
 export interface Services {
@@ -36,6 +37,7 @@ export default function createAndMount(
 	app.provide( MessagesKey, new Messages( services.messagesRepository ) );
 	app.provide( ItemSearchKey, services.itemSearcher );
 	app.provide( WikiRouterKey, services.wikiRouter );
+	app.provide( 'infoHtml', config.infoHtml ); // TODO proper key
 
 	return app.mount( config.rootSelector );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,30 +5,48 @@ import { BuildOptions, defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import banner from 'vite-plugin-banner';
 
-function getBuildConfig( isAppBuild: boolean ): BuildOptions {
-	if ( isAppBuild ) {
-		return {
-			target: 'es2015',
-		};
-	}
+function getBuildConfig( buildType = 'app' ): BuildOptions {
+	const target = 'es2015';
 
-	return {
-		target: 'es2015',
-		lib: {
-			entry: resolve( __dirname, 'src/init.ts' ),
-			name: 'main',
-			fileName: ( format ) => `SpecialNewLexeme.${format}.js`,
-			formats: [ 'cjs' ],
-		},
-		rollupOptions: {
-			external: [ 'vue', 'vuex' ],
-		},
-	};
+	switch ( buildType ) {
+		case 'preview':
+			return {
+				target,
+			};
+		case 'app':
+			return {
+				target,
+				lib: {
+					entry: resolve( __dirname, 'src/init.ts' ),
+					name: 'main',
+					fileName: ( format ) => `SpecialNewLexeme.${format}.js`,
+					formats: [ 'cjs' ],
+				},
+				rollupOptions: {
+					external: [ 'vue', 'vuex' ],
+				},
+			};
+		case 'info':
+			return {
+				target,
+				lib: {
+					entry: resolve( __dirname, 'src/components/InfoMessage.vue' ),
+					name: 'info',
+					fileName: ( format ) => `info.${format}.js`,
+					formats: [ 'cjs' ],
+				},
+				rollupOptions: {
+					external: [ 'vue', 'vuex' ],
+				},
+			};
+		default:
+			throw new Error( `Unknown build type ${buildType}` );
+	}
 }
 
 // https://vitejs.dev/config/
 export default defineConfig( {
-	build: getBuildConfig( !!process.env.BUILD_AS_APP ),
+	build: getBuildConfig( process.env.BUILD_TYPE ),
 	resolve: {
 		alias: {
 			'@wmde/wikit-tokens/variables': resolve(


### PR DESCRIPTION
This extracts the info message into a component – note that we can’t use
the Wikit Message component as it is, because that puts all of its
content into a <span> (so we can only use phrasing content inside), so
instead we repeat some of the relevant styles – and uses that in the
app. Additionally, the component is rendered into a static HTML file
using a new build configuration (which emits just that component as a
separate common.js bundle) and a small script (render-info.js) using
Vue’s SSR renderer to generate the HTML.

This static HTML can then be copied into WikibaseLexeme.git and used by
the special page for the no-JS version. All the UPPER_SNAKE_CASE
placeholders in the component are intended to be replaced with messages
or other HTML fragments by the special page. Currently, the App
component will show those unmodified; I’m not yet sure if we want the
App component to render the info message component again (with proper
messages this time), or if it should just grab the replaced HTML that
the special page already has, so that the component would never be
rendered client-side.

Bug: T305445