### PR TITLE
Create Action to infer LanguageCode

### DIFF
--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CREATE_LEXEME } from '@/store/actions';
+import { CREATE_LEXEME, HANDLE_LANGUAGE_CHANGE } from '@/store/actions';
 import { computed } from 'vue';
 import { useStore } from 'vuex';
 import { Button as WikitButton } from '@wmde/wikit-vue-components';
@@ -45,6 +45,10 @@ const lexicalCategory = computed( {
 		store.commit( SET_LEXICAL_CATEGORY, newLexicalCategory );
 	},
 } );
+const showSpellingVariantInput = computed( () => {
+	return store.state.languageCodeFromLanguageItem === null ||
+		store.state.languageCodeFromLanguageItem === false;
+} );
 const spellingVariant = computed( {
 	get(): string {
 		return store.state.spellingVariant;
@@ -84,6 +88,13 @@ const onSubmit = async () => {
 		// Error is already in store and handled by ErrorMessage component
 	}
 };
+
+const onLanguageSelect = async ( newLanguageId: string | null ) => {
+	if ( newLanguageId ) {
+		await store.dispatch( HANDLE_LANGUAGE_CHANGE, newLanguageId );
+	}
+};
+
 </script>
 
 <script lang="ts">
@@ -100,9 +111,11 @@ export default {
 			v-model="lemma"
 		/>
 		<language-input
-			v-model="language"
+			:model-value="language"
+			@update:model-value="onLanguageSelect"
 		/>
 		<spelling-variant-input
+			v-if="showSpellingVariantInput"
 			v-model="spellingVariant"
 		/>
 		<lexical-category-input

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -15,9 +15,9 @@ interface WikitMenuItem {
 
 const props = defineProps<Props>();
 
-const languageCodesProivder = useLanguageCodesProvider();
+const languageCodesProvider = useLanguageCodesProvider();
 
-const wbLexemeTermLanguages = languageCodesProivder.getLanguageCodes().map( ( lang ) => ( {
+const wbLexemeTermLanguages = languageCodesProvider.getLanguageCodes().map( ( lang ) => ( {
 	label: lang,
 	description: '',
 } ) );

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,7 +33,10 @@ export default function createAndMount(
 	services: Services,
 ): ComponentPublicInstance {
 	const app = createApp( App );
-	const store = initStore( services );
+	const languageCodesProvider = new ListLanguageCodesProvider(
+		config.wikibaseLexemeTermLanguages,
+	);
+	const store = initStore( { ...services, languageCodesProvider } );
 	app.use( store );
 
 	app.provide( ConfigKey, config );
@@ -42,7 +45,7 @@ export default function createAndMount(
 	app.provide( WikiRouterKey, services.wikiRouter );
 	app.provide(
 		LanguageCodesProviderKey,
-		new ListLanguageCodesProvider( config.wikibaseLexemeTermLanguages ),
+		languageCodesProvider,
 	);
 
 	return app.mount( config.rootSelector );

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -6,6 +6,7 @@ export interface SubmitError {
 export default interface RootState {
 	lemma: string;
 	language: string;
+	languageCodeFromLanguageItem: string | undefined | null | false;
 	lexicalCategory: string;
 	spellingVariant: string;
 	globalErrors: SubmitError[];

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -11,12 +11,14 @@
  * otherwise it’s preferred to directly use mutations.
  */
 
+import LangCodeRetriever from '@/data-access/LangCodeRetriever';
+import LanguageCodesProvider from '@/data-access/LanguageCodesProvider';
 import LexemeCreator from '@/data-access/LexemeCreator';
 import {
 	ActionContext,
 	ActionTree,
 } from 'vuex';
-import { ADD_ERRORS, CLEAR_ERRORS } from './mutations';
+import { ADD_ERRORS, CLEAR_ERRORS, SET_LANGUAGE, SET_LANGUAGE_CODE_FROM_LANGUAGE_ITEM, SET_SPELLING_VARIANT } from './mutations';
 import RootState from './RootState';
 /*
 import {
@@ -28,15 +30,21 @@ type RootContext = ActionContext<RootState, RootState>;
 type RootActions = ActionTree<RootState, RootState>;
 
 export const CREATE_LEXEME = 'createLexeme';
+export const HANDLE_LANGUAGE_CHANGE = 'handleLanguageChange';
 
-export default function createActions( lexemeCreator: LexemeCreator ): RootActions {
+export default function createActions(
+	lexemeCreator: LexemeCreator,
+	langCodeRetriever: LangCodeRetriever,
+	languageCodesProvider: LanguageCodesProvider,
+): RootActions {
 	return {
 		async [ CREATE_LEXEME ]( { state, commit }: RootContext ): Promise<string> {
 			commit( CLEAR_ERRORS );
 			try {
+				const spellingVariant = state.languageCodeFromLanguageItem || state.spellingVariant;
 				const lexemeId = await lexemeCreator.createLexeme(
 					state.lemma,
-					state.spellingVariant,
+					spellingVariant,
 					state.language,
 					state.lexicalCategory,
 				);
@@ -45,6 +53,23 @@ export default function createActions( lexemeCreator: LexemeCreator ): RootActio
 				commit( ADD_ERRORS, errors );
 				return Promise.reject( null );
 			}
+		},
+		async [ HANDLE_LANGUAGE_CHANGE ]( { commit }, newLanguageItemId: string ): Promise<void> {
+			commit( SET_LANGUAGE, newLanguageItemId );
+			commit( SET_LANGUAGE_CODE_FROM_LANGUAGE_ITEM, undefined );
+			commit( SET_SPELLING_VARIANT, '' );
+
+			if ( !newLanguageItemId ) {
+				return;
+			}
+
+			let langCode = await langCodeRetriever.getLanguageCodeFromItem( newLanguageItemId );
+
+			if ( typeof langCode === 'string' && !languageCodesProvider.isValid( langCode ) ) {
+				langCode = false;
+			}
+
+			commit( SET_LANGUAGE_CODE_FROM_LANGUAGE_ITEM, langCode );
 		},
 	};
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@
  */
 
 import LangCodeRetriever from '@/data-access/LangCodeRetriever';
+import LanguageCodesProvider from '@/data-access/LanguageCodesProvider';
 import LexemeCreator from '@/data-access/LexemeCreator';
 import {
 	createStore,
@@ -18,22 +19,24 @@ import RootState from './RootState';
 interface StoreServices {
 	lexemeCreator: LexemeCreator;
 	langCodeRetriever: LangCodeRetriever;
+	languageCodesProvider: LanguageCodesProvider;
 }
 
 export default function initStore( {
-	lexemeCreator,
+	lexemeCreator, langCodeRetriever, languageCodesProvider,
 }: StoreServices ): Store<RootState> {
 	return createStore( {
 		state(): RootState {
 			return {
 				lemma: '',
 				language: '',
+				languageCodeFromLanguageItem: undefined,
 				lexicalCategory: '',
 				spellingVariant: '',
 				globalErrors: [],
 			};
 		},
 		mutations,
-		actions: createActions( lexemeCreator ),
+		actions: createActions( lexemeCreator, langCodeRetriever, languageCodesProvider ),
 	} );
 }

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -12,6 +12,7 @@ export const SET_LEMMA = 'setLemma';
 export const SET_LANGUAGE = 'setLanguage';
 export const SET_LEXICAL_CATEGORY = 'setLexicalCategory';
 export const SET_SPELLING_VARIANT = 'setSpellingVariant';
+export const SET_LANGUAGE_CODE_FROM_LANGUAGE_ITEM = 'setLanguageCodeFromLanguageItem';
 export const ADD_ERRORS = 'addErrors';
 export const CLEAR_ERRORS = 'clearErrors';
 
@@ -27,6 +28,12 @@ export default {
 	},
 	[ SET_SPELLING_VARIANT ]( state: RootState, spellingVariant: string ): void {
 		state.spellingVariant = spellingVariant;
+	},
+	[ SET_LANGUAGE_CODE_FROM_LANGUAGE_ITEM ](
+		state: RootState,
+		langCode: string|null|false|undefined,
+	): void {
+		state.languageCodeFromLanguageItem = langCode;
 	},
 	[ ADD_ERRORS ]( state: RootState, errors: SubmitError[] ): void {
 		state.globalErrors.push( ...errors );

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -1,4 +1,4 @@
-import createActions, { CREATE_LEXEME } from '@/store/actions';
+import createActions, { CREATE_LEXEME, HANDLE_LANGUAGE_CHANGE } from '@/store/actions';
 import LexemeCreator from '@/data-access/LexemeCreator';
 import {
 	ADD_ERRORS,
@@ -6,15 +6,60 @@ import {
 } from '@/store/mutations';
 import RootState, { SubmitError } from '@/store/RootState';
 import { createStore } from 'vuex';
+import unusedLangCodeRetriever from '../../mocks/unusedLangCodeRetriever';
+import unusedLanguageCodesProvider from '../../mocks/unusedLanguageCodesProvider';
+import unusedLexemeCreator from '../../mocks/unusedLexemeCreator';
+import mutations from '@/store/mutations';
 
 describe( CREATE_LEXEME, () => {
 
-	it( 'calls lexemeCreator with the right data', async () => {
+	it( 'calls lexemeCreator with the inferred language variant', async () => {
 		const lexemeCreator: LexemeCreator = {
 			createLexeme: jest.fn().mockResolvedValue( 'L123' ),
 		};
 
-		const actions = createActions( lexemeCreator );
+		const actions = createActions(
+			lexemeCreator,
+			unusedLangCodeRetriever,
+			unusedLanguageCodesProvider,
+		);
+		const store = createStore( {
+			state(): RootState {
+				return {
+					lemma: 'foo',
+					spellingVariant: '',
+					language: 'Q123',
+					lexicalCategory: 'Q234',
+					languageCodeFromLanguageItem: 'fr',
+				} as RootState;
+			},
+			actions,
+			mutations: {
+				[ CLEAR_ERRORS ]: jest.fn(),
+			},
+		} );
+
+		const lexemeId = await store.dispatch( CREATE_LEXEME );
+
+		expect( lexemeId ).toBe( 'L123' );
+		expect( lexemeCreator.createLexeme ).toHaveBeenCalledWith(
+			'foo',
+			'fr',
+			'Q123',
+			'Q234',
+		);
+	} );
+
+	it( 'calls lexemeCreator with the language variant selected by the user', async () => {
+		const lexemeCreator: LexemeCreator = {
+			createLexeme: jest.fn().mockResolvedValue( 'L123' ),
+		};
+
+		const actions = createActions(
+			lexemeCreator,
+			unusedLangCodeRetriever,
+			unusedLanguageCodesProvider,
+		);
 		const store = createStore( {
 			state(): RootState {
 				return {
@@ -22,6 +67,7 @@ describe( CREATE_LEXEME, () => {
 					spellingVariant: 'de',
 					language: 'Q123',
 					lexicalCategory: 'Q234',
+					languageCodeFromLanguageItem: null,
 				} as RootState;
 			},
 			actions,
@@ -50,8 +96,10 @@ describe( CREATE_LEXEME, () => {
 			createLexeme: jest.fn().mockRejectedValue( errors ),
 		};
 
-		const actions = createActions( lexemeCreator );
-		const mutations = {
+		const actions = createActions( lexemeCreator, unusedLangCodeRetriever,
+			unusedLanguageCodesProvider,
+		);
+		const mockMutations = {
 			[ CLEAR_ERRORS ]: jest.fn(),
 			[ ADD_ERRORS ]: jest.fn(),
 		};
@@ -61,19 +109,191 @@ describe( CREATE_LEXEME, () => {
 					lemma: 'foo',
 					language: 'Q123',
 					lexicalCategory: 'Q234',
+					spellingVariant: 'en',
 				} as RootState;
 			},
 			actions,
-			mutations: mutations,
+			mutations: mockMutations,
 		} );
 
 		await expect( store.dispatch( CREATE_LEXEME ) ).rejects.toBe( null );
 
-		expect( mutations[ CLEAR_ERRORS ] ).toHaveBeenCalled();
-		expect( mutations[ ADD_ERRORS ] ).toHaveBeenCalledWith(
+		expect( mockMutations[ CLEAR_ERRORS ] ).toHaveBeenCalled();
+		expect( mockMutations[ ADD_ERRORS ] ).toHaveBeenCalledWith(
 			expect.anything(), // state
 			errors, // payload
 		);
 	} );
 
+} );
+
+describe( 'HANDLE_LANGUAGE_CHANGE', () => {
+	it( 'resets language fields in the store', async () => {
+		const actions = createActions(
+			unusedLexemeCreator,
+			{
+				getLanguageCodeFromItem: jest.fn().mockResolvedValue( null ),
+			},
+			unusedLanguageCodesProvider,
+		);
+
+		const store = createStore( {
+			state(): RootState {
+				return {
+					lemma: 'foo',
+					language: 'Q123',
+					lexicalCategory: 'Q234',
+					spellingVariant: 'bar',
+					languageCodeFromLanguageItem: false,
+				} as RootState;
+			},
+			actions,
+			mutations,
+		} );
+
+		const actionPromise = store.dispatch( HANDLE_LANGUAGE_CHANGE, 'Q456' );
+
+		expect( store.state.language ).toBe( 'Q456' );
+		expect( store.state.spellingVariant ).toBe( '' );
+		expect( store.state.languageCodeFromLanguageItem ).toBe( undefined );
+
+		await actionPromise;
+	} );
+
+	it( 'if no language item was selected, don\'t try to retrieve code', async () => {
+		const retrieveMethod = jest.fn();
+		const actions = createActions(
+			unusedLexemeCreator,
+			{
+				getLanguageCodeFromItem: retrieveMethod,
+			},
+			unusedLanguageCodesProvider,
+		);
+
+		const store = createStore( {
+			state(): RootState {
+				return {
+					lemma: 'foo',
+					language: 'Q123',
+					lexicalCategory: 'Q234',
+					spellingVariant: 'bar',
+					languageCodeFromLanguageItem: false,
+				} as RootState;
+			},
+			actions,
+			mutations,
+		} );
+
+		await store.dispatch( HANDLE_LANGUAGE_CHANGE, null );
+
+		expect( retrieveMethod ).not.toHaveBeenCalled();
+	} );
+
+	it( 'validates and sets to state if valid lang code was returned', async () => {
+		const isValidMock = jest.fn().mockReturnValue( true );
+		const actions = createActions(
+			unusedLexemeCreator,
+			{
+				getLanguageCodeFromItem: jest.fn().mockResolvedValue( 'de' ),
+			},
+			{
+				isValid: isValidMock,
+				getLanguageCodes: jest.fn(),
+			},
+		);
+
+		const store = createStore( {
+			state(): RootState {
+				return {
+					lemma: 'foo',
+					language: 'Q123',
+					lexicalCategory: 'Q234',
+					spellingVariant: 'bar',
+					languageCodeFromLanguageItem: false,
+				} as RootState;
+			},
+			actions,
+			mutations,
+		} );
+
+		await store.dispatch( HANDLE_LANGUAGE_CHANGE, 'Q456' );
+
+		expect( store.state.language ).toBe( 'Q456' );
+		expect( store.state.spellingVariant ).toBe( '' );
+		expect( store.state.languageCodeFromLanguageItem ).toBe( 'de' );
+		expect( isValidMock ).toHaveBeenCalledWith( 'de' );
+	} );
+
+	it( 'validates and sets false state if invalid lang code was returned', async () => {
+		const isValidMock = jest.fn().mockReturnValue( false );
+		const actions = createActions(
+			unusedLexemeCreator,
+			{
+				getLanguageCodeFromItem: jest.fn().mockResolvedValue( 'vandalism' ),
+			},
+			{
+				isValid: isValidMock,
+				getLanguageCodes: jest.fn(),
+			},
+		);
+
+		const store = createStore( {
+			state(): RootState {
+				return {
+					lemma: 'foo',
+					language: 'Q123',
+					lexicalCategory: 'Q234',
+					spellingVariant: 'bar',
+					languageCodeFromLanguageItem: false,
+				} as RootState;
+			},
+			actions,
+			mutations,
+		} );
+
+		await store.dispatch( HANDLE_LANGUAGE_CHANGE, 'Q456' );
+
+		expect( store.state.language ).toBe( 'Q456' );
+		expect( store.state.spellingVariant ).toBe( '' );
+		expect( store.state.languageCodeFromLanguageItem ).toBe( false );
+		expect( isValidMock ).toHaveBeenCalledWith( 'vandalism' );
+	} );
+
+	it.each( [
+		[ false ],
+		[ null ],
+	] )( 'passes through, without validation, the non-string retrieved language code: `%s`', async ( retrievedLangCodeResult ) => {
+		const isValidMock = jest.fn();
+		const actions = createActions(
+			unusedLexemeCreator,
+			{
+				getLanguageCodeFromItem: jest.fn().mockResolvedValue( retrievedLangCodeResult ),
+			},
+			{
+				isValid: isValidMock,
+				getLanguageCodes: jest.fn(),
+			},
+		);
+
+		const store = createStore( {
+			state(): RootState {
+				return {
+					lemma: 'foo',
+					language: 'Q123',
+					lexicalCategory: 'Q234',
+					spellingVariant: 'bar',
+					languageCodeFromLanguageItem: false,
+				} as RootState;
+			},
+			actions,
+			mutations,
+		} );
+
+		await store.dispatch( HANDLE_LANGUAGE_CHANGE, 'Q456' );
+
+		expect( store.state.language ).toBe( 'Q456' );
+		expect( store.state.spellingVariant ).toBe( '' );
+		expect( store.state.languageCodeFromLanguageItem ).toBe( retrievedLangCodeResult );
+		expect( isValidMock ).not.toHaveBeenCalled();
+	} );
 } );


### PR DESCRIPTION
Todo:
* [x] tests
* [x] validation
* [x] reacting to it

Cypress test will be updated in a separate commit. (In this commit, it probably asks for the language code of [September (Q123)](https://www.wikidata.org/wiki/Q123), which isn’t very nice but doesn’t need to block merging this.) Showing a warning will also be done separately.

Bug: T305542