### PR TITLE
Treat novalue like missing statement in LangCodeRetriever

### DIFF
--- a/src/data-access/LangCodeRetriever.ts
+++ b/src/data-access/LangCodeRetriever.ts
@@ -3,8 +3,8 @@ export default interface LangCodeRetriever {
 	/*
 	 * Returns the language code associated with the Item,
 	 * which may or may not be a valid language code, validation needs to be done by the caller.
-	 * Returns `null` if the Item does not have a language code associated with it.
-	 * Returns `false` if the Item has novalue or somevalue for the language code property.
+	 * Returns `null` if the Item does not have a language code associated with it (including a novalue statement).
+	 * Returns `false` if the Item has somevalue for the language code property.
 	 */
 	getLanguageCodeFromItem( itemId: string ): Promise<string | null | false>;
 }

--- a/src/data-access/apiBasedLangCodeRetriever.ts
+++ b/src/data-access/apiBasedLangCodeRetriever.ts
@@ -4,9 +4,16 @@ export type WbGetClaimsResponse = {
 	claims: StatementMap;
 };
 
-function getStringValueFromStatement( statement: Statement ): string | false {
-	if ( statement.mainsnak.snaktype !== 'value' ) {
-		return false;
+function getStringValueFromStatement( statement: Statement ): string | false | null {
+	switch ( statement.mainsnak.snaktype ) {
+		case 'value':
+			break;
+		case 'somevalue':
+			return false;
+		case 'novalue':
+			return null;
+		default:
+			throw new Error( `Unexpected snak type ${statement.mainsnak.snaktype}!` );
 	}
 
 	if ( statement.mainsnak.datavalue?.type !== 'string' ) {

--- a/tests/unit/data-access/MwApiLangCodeRetriever.test.ts
+++ b/tests/unit/data-access/MwApiLangCodeRetriever.test.ts
@@ -53,7 +53,7 @@ describe( 'MwApiLangCodeRetriever', () => {
 
 		const sut = new MwApiLangCodeRetriever( api, 'P218' );
 
-		expect( await sut.getLanguageCodeFromItem( 'Q9301' ) ).toBe( false );
+		expect( await sut.getLanguageCodeFromItem( 'Q9301' ) ).toBe( null );
 	} );
 
 	it( 'returns the language code from the normal ranked statement if there is no preferred one', async () => {


### PR DESCRIPTION
Somevalue should be treated like an error, but novalue can be considered equivalent to a missing statement for our purposes (i.e. shows no warning message).

Bug: T305542