### PR TITLE
Extract LanguageCodesProvider interface

### DIFF
--- a/src/data-access/LanguageCodesProvider.ts
+++ b/src/data-access/LanguageCodesProvider.ts
@@ -1,4 +1,9 @@
-export default class LanguageCodesProvider {
+export default interface LanguageCodesProvider {
+	getLanguageCodes(): readonly string[];
+	isValid( languageCode: string ): boolean;
+}
+
+export class ListLanguageCodesProvider implements LanguageCodesProvider {
 	public constructor(
 		private readonly validLanguageCodes: string[],
 	) {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import { WikiRouterKey } from './plugins/WikiRouterPlugin/WikiRouter';
 import WikiRouter from './plugins/WikiRouterPlugin/WikiRouter';
 import LangCodeRetriever from './data-access/LangCodeRetriever';
 import { LanguageCodesProviderKey } from './plugins/LanguageCodesProviderPlugin/LanguageCodesProvider';
-import LanguageCodesProvider from './data-access/LanguageCodesProvider';
+import { ListLanguageCodesProvider } from './data-access/LanguageCodesProvider';
 
 export interface CreateAndMountConfig extends Config {
 	rootSelector: string;
@@ -42,7 +42,7 @@ export default function createAndMount(
 	app.provide( WikiRouterKey, services.wikiRouter );
 	app.provide(
 		LanguageCodesProviderKey,
-		new LanguageCodesProvider( config.wikibaseLexemeTermLanguages ),
+		new ListLanguageCodesProvider( config.wikibaseLexemeTermLanguages ),
 	);
 
 	return app.mount( config.rootSelector );

--- a/tests/mocks/unusedLanguageCodesProvider.ts
+++ b/tests/mocks/unusedLanguageCodesProvider.ts
@@ -1,0 +1,12 @@
+import LanguageCodesProvider from '@/data-access/LanguageCodesProvider';
+
+const unusedLanguageCodesProvider: LanguageCodesProvider = {
+	getLanguageCodes: (): never => {
+		throw new Error( 'This test should not use LanguageCodesProvider!' );
+	},
+	isValid: (): never => {
+		throw new Error( 'This test should not use LanguageCodesProvider!' );
+	},
+};
+
+export default unusedLanguageCodesProvider;

--- a/tests/unit/data-access/LangCodeProvider.test.ts
+++ b/tests/unit/data-access/LangCodeProvider.test.ts
@@ -1,10 +1,10 @@
-import LanguageCodesProvider from '@/data-access/LanguageCodesProvider';
+import { ListLanguageCodesProvider } from '@/data-access/LanguageCodesProvider';
 
 describe( 'LanguageCodesProvider', () => {
 	describe( 'isValidLangCode', () => {
 		it( 'returns "true" for a valid language code', () => {
 			const listOfValidCodes = [ 'en', 'en-gb', 'de' ];
-			const sut = new LanguageCodesProvider( listOfValidCodes );
+			const sut = new ListLanguageCodesProvider( listOfValidCodes );
 
 			const actual = sut.isValid( 'en-gb' );
 
@@ -12,7 +12,7 @@ describe( 'LanguageCodesProvider', () => {
 		} );
 		it( 'returns "false" for an invalid language code', () => {
 			const listOfValidCodes = [ 'en', 'en-gb', 'de' ];
-			const sut = new LanguageCodesProvider( listOfValidCodes );
+			const sut = new ListLanguageCodesProvider( listOfValidCodes );
 
 			const actual = sut.isValid( 'raccoon' );
 


### PR DESCRIPTION
We didn’t think we needed this initially, but in the tests it’s very annoying when TypeScript complains about the missing private property validLanguageCodes for every fake implementation.

Bug: T305542
Co-Authored-By: Michael Große <michael.grosse@wikimedia.de>