### PR TITLE
Add warning message for invalid language code

### DIFF
--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -11,6 +11,7 @@ interface Props {
 	placeholder: string;
 	value: string | null;
 	searchForItems: ( searchTerm: string, offset?: number ) => Promise<SearchedItemOption[]>;
+	error?: { type: 'error'|'warning'; message: string };
 }
 const props = defineProps<Props>();
 
@@ -99,6 +100,7 @@ const messages = useMessages();
 		:search-input="searchInput"
 		:menu-items="searchSuggestions"
 		:value="selectedOption"
+		:error="error"
 		@update:search-input="onSearchInput"
 		@scroll="onScroll"
 		@input="onOptionSelected"

--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { useStore } from 'vuex';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import ItemLookup from '@/components/ItemLookup.vue';
 import { useItemSearch } from '@/plugins/ItemSearchPlugin/ItemSearch';
+import { computed } from 'vue';
 
 interface Props {
 	modelValue: string | null;
@@ -16,6 +18,17 @@ const messages = useMessages();
 const searcher = useItemSearch();
 const searchForItems = searcher.searchItems.bind( searcher );
 
+const store = useStore();
+
+const error = computed( () => {
+	if ( store.state.languageCodeFromLanguageItem !== false ) {
+		return undefined;
+	}
+	return {
+		type: 'warning' as const,
+		message: messages.getUnescaped( 'wikibaselexeme-newlexeme-invalid-language-code-warning' ),
+	};
+} );
 </script>
 
 <script lang="ts">
@@ -33,6 +46,7 @@ export default {
 			:placeholder="messages.getUnescaped( 'wikibaselexeme-newlexeme-language-placeholder' )"
 			:value="modelValue"
 			:search-for-items="searchForItems"
+			:error="error"
 			@update:model-value="$emit( 'update:modelValue', $event )"
 		/>
 	</div>

--- a/src/plugins/MessagesPlugin/DevMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/DevMessagesRepository.ts
@@ -14,6 +14,7 @@ const messages: Record<MessageKeys, string> = {
 	'wikibaselexeme-newlexeme-submit-error': 'The server encountered a temporary error and could not complete your request. Please try again.',
 	'wikibaselexeme-newlexeme-error-no-lemma': 'Lemma field is empty, please make an entry.',
 	'wikibaselexeme-newlexeme-error-lemma-is-too-long': 'FIXME (copy is missing!)',
+	'wikibaselexeme-newlexeme-invalid-language-code-warning': 'This Item has an unrecognized language code. Please select one below.',
 	'wikibaselexeme-newlexeme-no-results': 'FIXME (copy is missing!)',
 	'wikibase-shortcopyrightwarning': 'By clicking "$1", you agree to the [[$2|terms of use]], and you irrevocably agree to release your contribution under the [$3 $4].',
 	copyrightpage: '{{ns:project}}:Copyrights',

--- a/src/plugins/MessagesPlugin/MessageKeys.ts
+++ b/src/plugins/MessagesPlugin/MessageKeys.ts
@@ -11,6 +11,7 @@ type MessageKeys
  | 'wikibaselexeme-newlexeme-submit-error'
  | 'wikibaselexeme-newlexeme-error-no-lemma'
  | 'wikibaselexeme-newlexeme-error-lemma-is-too-long'
+ | 'wikibaselexeme-newlexeme-invalid-language-code-warning'
  | 'wikibaselexeme-newlexeme-no-results'
  | 'wikibase-shortcopyrightwarning'
  | 'copyrightpage';


### PR DESCRIPTION
If there is a language code statement on the language item (including a somevalue statement, but not a novalue statement), but its value is not a valid language code, show a warning message to the user.

Bug: T305542