### PR TITLE
Don't crash if no languageCodeProperty configured

### DIFF
--- a/src/data-access/LangCodeRetriever.ts
+++ b/src/data-access/LangCodeRetriever.ts
@@ -3,7 +3,7 @@ export default interface LangCodeRetriever {
 	/*
 	 * Returns the language code associated with the Item,
 	 * which may or may not be a valid language code, validation needs to be done by the caller.
-	 * Returns `null` if the Item has no associated language code (including a novalue statement).
+	 * Returns `null` if there is no language code available (incl. missing or novalue statement).
 	 * Returns `false` if the Item has somevalue for the language code property.
 	 */
 	getLanguageCodeFromItem( itemId: string ): Promise<string | null | false>;

--- a/src/data-access/MwApiLangCodeRetriever.ts
+++ b/src/data-access/MwApiLangCodeRetriever.ts
@@ -5,17 +5,18 @@ import { processWbGetClaimsResponse, WbGetClaimsResponse } from './apiBasedLangC
 export default class MwApiLangCodeRetriever implements LangCodeRetriever {
 
 	private readonly api: MwApi;
-	private readonly languageCodeProperty: string;
+	private readonly languageCodeProperty: string | null;
 
-	public constructor( api: MwApi, languageCodeProperty: string ) {
-		if ( typeof languageCodeProperty !== 'string' ) {
-			throw new Error( `Expected languageCodeProperty to be propertyId but received ${languageCodeProperty} instead!` );
-		}
+	public constructor( api: MwApi, languageCodeProperty: string | null ) {
 		this.api = api;
 		this.languageCodeProperty = languageCodeProperty;
 	}
 
 	public async getLanguageCodeFromItem( itemId: string ): Promise<string | null | false> {
+		if ( !this.languageCodeProperty ) {
+			return null;
+		}
+
 		const response = await this.api.get( {
 			action: 'wbgetclaims',
 			entity: itemId,


### PR DESCRIPTION
Especially in CI, there can be no language code property configured. The
app should still work in that case.

Bug: T306170