### PR TITLE
Always handle change in the Language input

### DIFF
--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -90,9 +90,7 @@ const onSubmit = async () => {
 };
 
 const onLanguageSelect = async ( newLanguageId: string | null ) => {
-	if ( newLanguageId ) {
-		await store.dispatch( HANDLE_LANGUAGE_CHANGE, newLanguageId );
-	}
+	await store.dispatch( HANDLE_LANGUAGE_CHANGE, newLanguageId );
 };
 
 </script>

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -77,11 +77,11 @@ describe( 'NewLexemeForm', () => {
 		await wrapper.find( '.wbl-snl-language-lookup .wikit-OptionsMenu__item' ).trigger( 'click' );
 
 		expect( wrapper.find( '.wbl-snl-spelling-variant-lookup' ).exists() ).toBe( false );
-
 		expect( testStore.state.language ).toBe( 'Q123' );
 		expect( testStore.state.languageCodeFromLanguageItem ).toBe( 'de' );
 
 		await languageLookup.setValue( '=Q12' );
+		// don’t click any option ⇒ nothing actually selected
 
 		expect( wrapper.find( '.wbl-snl-spelling-variant-lookup' ).exists() ).toBe( false );
 		expect( testStore.state.language ).toBe( null );

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -80,6 +80,12 @@ describe( 'NewLexemeForm', () => {
 
 		expect( testStore.state.language ).toBe( 'Q123' );
 		expect( testStore.state.languageCodeFromLanguageItem ).toBe( 'de' );
+
+		await languageLookup.setValue( '=Q12' );
+
+		expect( wrapper.find( '.wbl-snl-spelling-variant-lookup' ).exists() ).toBe( false );
+		expect( testStore.state.language ).toBe( null );
+		expect( testStore.state.languageCodeFromLanguageItem ).toBe( undefined );
 	} );
 
 	it( 'shows warning message if language code is not valid', async () => {


### PR DESCRIPTION
This if-wrapper was probably just left over from development, but we
also want to remove the selected language value from the store when it
is deselected in the Lookup.