### PR TITLE
Show and Filter Language Names in Spelling Variant Lookup

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,17 +20,17 @@
 				licenseUrl: '',
 				licenseName: '',
 				wikibaseLexemeTermLanguages: new Map([
-  [ 'en', 'English' ],
-  [ 'en-ca', 'Canadian English' ],
-  [ 'en-gb', 'British English' ],
-  [ 'enm', 'Middle English' ],
-  [ 'es', 'Spanish' ],
-  [ 'de', 'German' ],
-  [ 'aeb', 'Tunisian Arabic' ],
-  [ 'af', 'Afrikaans' ],
-  [ 'eo', 'Esperanto' ],
-  [ 'ha-arab', 'Hausa in Arab script' ]
-]),
+					[ 'en', 'English' ],
+					[ 'en-ca', 'Canadian English' ],
+					[ 'en-gb', 'British English' ],
+					[ 'enm', 'Middle English' ],
+					[ 'es', 'Spanish' ],
+					[ 'de', 'German' ],
+					[ 'aeb', 'Tunisian Arabic' ],
+					[ 'af', 'Afrikaans' ],
+					[ 'eo', 'Esperanto' ],
+					[ 'ha-arab', 'Hausa in Arab script' ]
+				]),
 			};
 			const services = {
 				itemSearcher: new DevItemSearcher(),

--- a/index.html
+++ b/index.html
@@ -19,18 +19,18 @@
 				rootSelector: '#app',
 				licenseUrl: '',
 				licenseName: '',
-				wikibaseLexemeTermLanguages: {
-					en: 'English',
-					'en-ca': 'Canadian English',
-					'en-gb': 'British English',
-					enm: 'Middle English',
-					es: 'Spanish',
-					de: 'German',
-					aeb: 'Tunisian Arabic',
-					af: 'Afrikaans',
-					eo: 'Esperanto',
-					'ha-arab': 'Hausa in Arab script',
-				},
+				wikibaseLexemeTermLanguages: new Map([
+  [ 'en', 'English' ],
+  [ 'en-ca', 'Canadian English' ],
+  [ 'en-gb', 'British English' ],
+  [ 'enm', 'Middle English' ],
+  [ 'es', 'Spanish' ],
+  [ 'de', 'German' ],
+  [ 'aeb', 'Tunisian Arabic' ],
+  [ 'af', 'Afrikaans' ],
+  [ 'eo', 'Esperanto' ],
+  [ 'ha-arab', 'Hausa in Arab script' ]
+]),
 			};
 			const services = {
 				itemSearcher: new DevItemSearcher(),

--- a/index.html
+++ b/index.html
@@ -19,7 +19,18 @@
 				rootSelector: '#app',
 				licenseUrl: '',
 				licenseName: '',
-				wikibaseLexemeTermLanguages: [ 'en', 'en-ca', 'en-gb', 'enm', 'es', 'est', 'esp', 'esk', 'aa', 'bcc', 'ca', 'de', 'ff', 'ga', 'ha-arab' ],
+				wikibaseLexemeTermLanguages: {
+					en: 'English',
+					'en-ca': 'Canadian English',
+					'en-gb': 'British English',
+					enm: 'Middle English',
+					es: 'Spanish',
+					de: 'German',
+					aeb: 'Tunisian Arabic',
+					af: 'Afrikaans',
+					eo: 'Esperanto',
+					'ha-arab': 'Hausa in Arab script',
+				},
 			};
 			const services = {
 				itemSearcher: new DevItemSearcher(),

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -18,10 +18,11 @@ interface WikitMenuItem {
 const props = defineProps<Props>();
 
 const languageCodesProvider = useLanguageCodesProvider();
+const messages = useMessages();
 
 const wbLexemeTermLanguages = languageCodesProvider.getLanguageCodes().map(
 	( [ code, name ]: [ string, string ] ) => ( {
-		label: `${name} (${code})`,
+		label: messages.getUnescaped( 'wikibase-lexeme-lemma-language-option', name, code ),
 		value: code,
 		description: '',
 	} ),
@@ -63,7 +64,6 @@ const onOptionSelected = ( value: unknown ) => {
 	emit( 'update:modelValue', selectedValue );
 };
 
-const messages = useMessages();
 </script>
 
 <script lang="ts">

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -20,12 +20,15 @@ const props = defineProps<Props>();
 const languageCodesProvider = useLanguageCodesProvider();
 const messages = useMessages();
 
-const wbLexemeTermLanguages = languageCodesProvider.getLanguageCodes().map(
-	( [ code, name ]: [ string, string ] ) => ( {
-		label: messages.getUnescaped( 'wikibase-lexeme-lemma-language-option', name, code ),
-		value: code,
-		description: '',
-	} ),
+const wbLexemeTermLanguages: WikitMenuItem[] = [];
+languageCodesProvider.getLanguages().forEach(
+	( name, code ) => {
+		wbLexemeTermLanguages.push( {
+			label: messages.getUnescaped( 'wikibase-lexeme-lemma-language-option', name, code ),
+			value: code,
+			description: '',
+		} );
+	},
 );
 
 const menuItems = ref( [] as WikitMenuItem[] );

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -11,16 +11,20 @@ interface Props {
 interface WikitMenuItem {
 	label: string;
 	description: string;
+	value: string;
 }
 
 const props = defineProps<Props>();
 
 const languageCodesProvider = useLanguageCodesProvider();
 
-const wbLexemeTermLanguages = languageCodesProvider.getLanguageCodes().map( ( lang ) => ( {
-	label: lang,
-	description: '',
-} ) );
+const wbLexemeTermLanguages = languageCodesProvider.getLanguageCodes().map(
+	( [ code, name ]: [ string, string ] ) => ( {
+		label: `${name} (${code})`,
+		value: code,
+		description: '',
+	} ),
+);
 
 const menuItems = ref( [] as WikitMenuItem[] );
 
@@ -39,7 +43,8 @@ const onSearchInput = ( inputValue: string ) => {
 	}
 
 	menuItems.value = wbLexemeTermLanguages.filter(
-		( lang ) => lang.label.startsWith( lowerCaseInputValue ) );
+		( lang ) => ( new RegExp( `\\b${inputValue}`, 'i' ) ).test( lang.label ),
+	);
 
 	searchInput.value = inputValue;
 };
@@ -53,7 +58,7 @@ const selectedOption = computed( () => {
 } );
 
 const onOptionSelected = ( value: unknown ) => {
-	const selectedValue = value === null ? null : ( value as WikitMenuItem ).label;
+	const selectedValue = value === null ? null : ( value as WikitMenuItem ).value;
 	emit( 'update:modelValue', selectedValue );
 };
 

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -41,7 +41,6 @@ const emit = defineEmits( {
 
 const searchInput = ref( '' );
 const onSearchInput = ( inputValue: string ) => {
-	const lowerCaseInputValue = inputValue.toLowerCase();
 	if ( inputValue.trim() === '' ) {
 		menuItems.value = [];
 		return;

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
+import { escapeRegExp } from 'lodash';
 import WikitLookup from './WikitLookup';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import { useLanguageCodesProvider } from '@/plugins/LanguageCodesProviderPlugin/LanguageCodesProvider';
@@ -43,7 +44,7 @@ const onSearchInput = ( inputValue: string ) => {
 	}
 
 	menuItems.value = wbLexemeTermLanguages.filter(
-		( lang ) => ( new RegExp( `\\b${inputValue}`, 'i' ) ).test( lang.label ),
+		( lang ) => ( new RegExp( `\\b${escapeRegExp( inputValue )}`, 'i' ) ).test( lang.label ),
 	);
 
 	searchInput.value = inputValue;

--- a/src/data-access/LanguageCodesProvider.ts
+++ b/src/data-access/LanguageCodesProvider.ts
@@ -1,5 +1,5 @@
 export default interface LanguageCodesProvider {
-	getLanguageCodes(): [string, string][];
+	getLanguages(): Map<string, string>;
 	isValid( languageCode: string ): boolean;
 }
 
@@ -13,8 +13,8 @@ export class ListLanguageCodesProvider implements LanguageCodesProvider {
 		this.validLanguageCodes = new Map( Object.entries( validLanguageCodes ) );
 	}
 
-	public getLanguageCodes(): [string, string][] {
-		return [ ...this.validLanguageCodes ];
+	public getLanguages(): Map<string, string> {
+		return this.validLanguageCodes;
 	}
 
 	public isValid( langCode: string ): boolean {

--- a/src/data-access/LanguageCodesProvider.ts
+++ b/src/data-access/LanguageCodesProvider.ts
@@ -14,7 +14,7 @@ export class ListLanguageCodesProvider implements LanguageCodesProvider {
 	}
 
 	public getLanguageCodes(): [string, string][] {
-		return Array.from( this.validLanguageCodes.entries() );
+		return [ ...this.validLanguageCodes ];
 	}
 
 	public isValid( langCode: string ): boolean {

--- a/src/data-access/LanguageCodesProvider.ts
+++ b/src/data-access/LanguageCodesProvider.ts
@@ -1,18 +1,23 @@
 export default interface LanguageCodesProvider {
-	getLanguageCodes(): readonly string[];
+	getLanguageCodes(): [string, string][];
 	isValid( languageCode: string ): boolean;
 }
 
 export class ListLanguageCodesProvider implements LanguageCodesProvider {
-	public constructor(
-		private readonly validLanguageCodes: string[],
-	) {}
 
-	public getLanguageCodes(): readonly string[] {
-		return this.validLanguageCodes;
+	private readonly validLanguageCodes: Map<string, string>;
+
+	public constructor(
+		validLanguageCodes: Record<string, string>,
+	) {
+		this.validLanguageCodes = new Map( Object.entries( validLanguageCodes ) );
+	}
+
+	public getLanguageCodes(): [string, string][] {
+		return Array.from( this.validLanguageCodes.entries() );
 	}
 
 	public isValid( langCode: string ): boolean {
-		return this.validLanguageCodes.includes( langCode );
+		return this.validLanguageCodes.has( langCode );
 	}
 }

--- a/src/data-access/LanguageCodesProvider.ts
+++ b/src/data-access/LanguageCodesProvider.ts
@@ -3,7 +3,7 @@ export default interface LanguageCodesProvider {
 	isValid( languageCode: string ): boolean;
 }
 
-export class ListLanguageCodesProvider implements LanguageCodesProvider {
+export class MapLanguageCodesProvider implements LanguageCodesProvider {
 
 	private readonly validLanguages: Map<string, string>;
 

--- a/src/data-access/LanguageCodesProvider.ts
+++ b/src/data-access/LanguageCodesProvider.ts
@@ -5,19 +5,19 @@ export default interface LanguageCodesProvider {
 
 export class ListLanguageCodesProvider implements LanguageCodesProvider {
 
-	private readonly validLanguageCodes: Map<string, string>;
+	private readonly validLanguages: Map<string, string>;
 
 	public constructor(
-		validLanguageCodes: Record<string, string>,
+		validLanguages: Map<string, string>,
 	) {
-		this.validLanguageCodes = new Map( Object.entries( validLanguageCodes ) );
+		this.validLanguages = validLanguages;
 	}
 
 	public getLanguages(): Map<string, string> {
-		return this.validLanguageCodes;
+		return this.validLanguages;
 	}
 
 	public isValid( langCode: string ): boolean {
-		return this.validLanguageCodes.has( langCode );
+		return this.validLanguages.has( langCode );
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ import { WikiRouterKey } from './plugins/WikiRouterPlugin/WikiRouter';
 import WikiRouter from './plugins/WikiRouterPlugin/WikiRouter';
 import LangCodeRetriever from './data-access/LangCodeRetriever';
 import { LanguageCodesProviderKey } from './plugins/LanguageCodesProviderPlugin/LanguageCodesProvider';
-import { ListLanguageCodesProvider } from './data-access/LanguageCodesProvider';
+import { MapLanguageCodesProvider } from './data-access/LanguageCodesProvider';
 
 export interface CreateAndMountConfig extends Config {
 	rootSelector: string;
@@ -33,7 +33,7 @@ export default function createAndMount(
 	services: Services,
 ): ComponentPublicInstance {
 	const app = createApp( App );
-	const languageCodesProvider = new ListLanguageCodesProvider(
+	const languageCodesProvider = new MapLanguageCodesProvider(
 		config.wikibaseLexemeTermLanguages,
 	);
 	const store = initStore( { ...services, languageCodesProvider } );

--- a/src/plugins/ConfigPlugin/Config.ts
+++ b/src/plugins/ConfigPlugin/Config.ts
@@ -6,7 +6,7 @@ import {
 export interface Config {
 	readonly licenseUrl: string;
 	readonly licenseName: string;
-	readonly wikibaseLexemeTermLanguages: string[];
+	readonly wikibaseLexemeTermLanguages: Record<string, string>;
 }
 
 export const ConfigKey: InjectionKey<Config> = Symbol( 'Config' );

--- a/src/plugins/ConfigPlugin/Config.ts
+++ b/src/plugins/ConfigPlugin/Config.ts
@@ -6,7 +6,7 @@ import {
 export interface Config {
 	readonly licenseUrl: string;
 	readonly licenseName: string;
-	readonly wikibaseLexemeTermLanguages: Record<string, string>;
+	readonly wikibaseLexemeTermLanguages: Map<string, string>;
 }
 
 export const ConfigKey: InjectionKey<Config> = Symbol( 'Config' );

--- a/src/plugins/MessagesPlugin/DevMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/DevMessagesRepository.ts
@@ -16,6 +16,7 @@ const messages: Record<MessageKeys, string> = {
 	'wikibaselexeme-newlexeme-error-lemma-is-too-long': 'FIXME (copy is missing!)',
 	'wikibaselexeme-newlexeme-invalid-language-code-warning': 'This Item has an unrecognized language code. Please select one below.',
 	'wikibaselexeme-newlexeme-no-results': 'FIXME (copy is missing!)',
+	'wikibase-lexeme-lemma-language-option': '$1 ($2)',
 	'wikibase-shortcopyrightwarning': 'By clicking "$1", you agree to the [[$2|terms of use]], and you irrevocably agree to release your contribution under the [$3 $4].',
 	copyrightpage: '{{ns:project}}:Copyrights',
 };

--- a/src/plugins/MessagesPlugin/MessageKeys.ts
+++ b/src/plugins/MessagesPlugin/MessageKeys.ts
@@ -13,6 +13,7 @@ type MessageKeys
  | 'wikibaselexeme-newlexeme-error-lemma-is-too-long'
  | 'wikibaselexeme-newlexeme-invalid-language-code-warning'
  | 'wikibaselexeme-newlexeme-no-results'
+ | 'wikibase-lexeme-lemma-language-option'
  | 'wikibase-shortcopyrightwarning'
  | 'copyrightpage';
 

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -35,7 +35,7 @@ describe( 'NewLexemeForm', () => {
 					[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ LanguageCodesProviderKey as symbol ]: {
-						getLanguageCodes: () => [ 'en', 'en-ca', 'de' ],
+						getLanguages: () => new Map( [ [ 'en', 'English' ] ] ),
 					},
 					[ WikiRouterKey as symbol ]: null,
 				},

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -135,7 +135,7 @@ describe( 'NewLexemeForm', () => {
 	it( 'updates the store if a language is selected in the spelling variant input', async () => {
 		const languageCodesProvider: LanguageCodesProvider = {
 			isValid: jest.fn().mockReturnValue( true ),
-			getLanguageCodes: jest.fn().mockReturnValue( [ 'de' ] ),
+			getLanguageCodes: jest.fn().mockReturnValue( [ [ 'de', 'German' ] ] ),
 		};
 		const testStore = initStore( {
 			lexemeCreator: unusedLexemeCreator,
@@ -230,7 +230,7 @@ describe( 'NewLexemeForm', () => {
 					[ ConfigKey as symbol ]: {},
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ LanguageCodesProviderKey as symbol ]: {
-						getLanguageCodes: () => [ 'en-gb' ],
+						getLanguageCodes: () => [ [ 'en-gb', 'British English' ] ],
 					},
 					[ WikiRouterKey as symbol ]: { goToTitle },
 				},

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -34,9 +34,7 @@ describe( 'NewLexemeForm', () => {
 					[ ConfigKey as symbol ]: {},
 					[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
-					[ LanguageCodesProviderKey as symbol ]: {
-						getLanguages: () => new Map( [ [ 'en', 'English' ] ] ),
-					},
+					[ LanguageCodesProviderKey as symbol ]: unusedLanguageCodesProvider,
 					[ WikiRouterKey as symbol ]: null,
 				},
 			},

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -58,7 +58,7 @@ describe( 'NewLexemeForm', () => {
 			langCodeRetriever: { getLanguageCodeFromItem: jest.fn().mockResolvedValue( 'de' ) },
 			languageCodesProvider: {
 				isValid: jest.fn().mockReturnValue( true ),
-				getLanguageCodes: jest.fn(),
+				getLanguages: jest.fn(),
 			},
 		} );
 
@@ -94,7 +94,7 @@ describe( 'NewLexemeForm', () => {
 	it( 'shows warning message if language code is not valid', async () => {
 		const languageCodesProvider: LanguageCodesProvider = {
 			isValid: jest.fn().mockReturnValue( false ),
-			getLanguageCodes: jest.fn().mockReturnValue( [ 'de' ] ),
+			getLanguages: jest.fn().mockReturnValue( new Map() ),
 		};
 		const testStore = initStore( {
 			lexemeCreator: unusedLexemeCreator,
@@ -138,7 +138,7 @@ describe( 'NewLexemeForm', () => {
 	it( 'updates the store if a language is selected in the spelling variant input', async () => {
 		const languageCodesProvider: LanguageCodesProvider = {
 			isValid: jest.fn().mockReturnValue( true ),
-			getLanguageCodes: jest.fn().mockReturnValue( [ [ 'de', 'German' ] ] ),
+			getLanguages: jest.fn().mockReturnValue( new Map( [ [ 'de', 'German' ] ] ) ),
 		};
 		const testStore = initStore( {
 			lexemeCreator: unusedLexemeCreator,
@@ -184,7 +184,7 @@ describe( 'NewLexemeForm', () => {
 			langCodeRetriever: { getLanguageCodeFromItem: jest.fn().mockResolvedValue( 'de' ) },
 			languageCodesProvider: {
 				isValid: jest.fn().mockReturnValue( true ),
-				getLanguageCodes: jest.fn(),
+				getLanguages: jest.fn(),
 			},
 		} );
 		const wrapper = mount( NewLexemeForm, {
@@ -234,7 +234,7 @@ describe( 'NewLexemeForm', () => {
 					[ ConfigKey as symbol ]: {},
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ LanguageCodesProviderKey as symbol ]: {
-						getLanguageCodes: () => [ [ 'en-gb', 'British English' ] ],
+						getLanguages: () => new Map( [ [ 'en-gb', 'British English' ] ] ),
 					},
 					[ WikiRouterKey as symbol ]: { goToTitle },
 					[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -11,6 +11,8 @@ import { WikiRouterKey } from '@/plugins/WikiRouterPlugin/WikiRouter';
 import unusedLangCodeRetriever from '../mocks/unusedLangCodeRetriever';
 import unusedLanguageCodesProvider from '../mocks/unusedLanguageCodesProvider';
 import { nextTick } from 'vue';
+import Messages, { MessagesKey } from '@/plugins/MessagesPlugin/Messages';
+import DevMessagesRepository from '@/plugins/MessagesPlugin/DevMessagesRepository';
 
 jest.mock( 'lodash/debounce', () => jest.fn( ( fn ) => fn ) );
 
@@ -30,6 +32,7 @@ describe( 'NewLexemeForm', () => {
 				plugins: [ store ],
 				provide: {
 					[ ConfigKey as symbol ]: {},
+					[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ LanguageCodesProviderKey as symbol ]: {
 						getLanguageCodes: () => [ 'en', 'en-ca', 'de' ],
@@ -151,6 +154,7 @@ describe( 'NewLexemeForm', () => {
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ LanguageCodesProviderKey as symbol ]: languageCodesProvider,
 					[ WikiRouterKey as symbol ]: null,
+					[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),
 				},
 			},
 		} );
@@ -233,6 +237,7 @@ describe( 'NewLexemeForm', () => {
 						getLanguageCodes: () => [ [ 'en-gb', 'British English' ] ],
 					},
 					[ WikiRouterKey as symbol ]: { goToTitle },
+					[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),
 				},
 			},
 		} );

--- a/tests/mocks/unusedLanguageCodesProvider.ts
+++ b/tests/mocks/unusedLanguageCodesProvider.ts
@@ -1,7 +1,7 @@
 import LanguageCodesProvider from '@/data-access/LanguageCodesProvider';
 
 const unusedLanguageCodesProvider: LanguageCodesProvider = {
-	getLanguageCodes: (): never => {
+	getLanguages: (): never => {
 		throw new Error( 'This test should not use LanguageCodesProvider!' );
 	},
 	isValid: (): never => {

--- a/tests/unit/components/SpellingVariantInput.test.ts
+++ b/tests/unit/components/SpellingVariantInput.test.ts
@@ -60,13 +60,13 @@ describe( 'SpellingVariantInput', () => {
 	describe( 'suggested options', () => {
 		it.each( [
 			[
-				'Tun would open Tunisia',
+				'Tun would open Tunisian',
 				[ [ 'en', 'English' ], [ 'aeb-latn', 'Tunisian Arabic (Latin script)' ], [ 'de', 'German' ] ],
 				'Tun',
 				[ 'aeb-latn' ],
 			],
 			[
-				'matching is not fuzzy - tsa does not match Tunisia',
+				'matching is not fuzzy - tsa does not match Tunisian',
 				[ [ 'en', 'English' ], [ 'aeb-latn', 'Tunisian Arabic (Latin script)' ], [ 'de', 'German' ] ],
 				'tsa',
 				[],

--- a/tests/unit/components/SpellingVariantInput.test.ts
+++ b/tests/unit/components/SpellingVariantInput.test.ts
@@ -4,7 +4,7 @@ import { Lookup as WikitLookup } from '@wmde/wikit-vue-components';
 import { LanguageCodesProviderKey } from '@/plugins/LanguageCodesProviderPlugin/LanguageCodesProvider';
 import DevMessagesRepository from '@/plugins/MessagesPlugin/DevMessagesRepository';
 import Messages, { MessagesKey } from '@/plugins/MessagesPlugin/Messages';
-import { ListLanguageCodesProvider } from '@/data-access/LanguageCodesProvider';
+import { MapLanguageCodesProvider } from '@/data-access/LanguageCodesProvider';
 
 const termLanguagesConfig = new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
 
@@ -16,7 +16,7 @@ function createLookup( config: Record<string, unknown> = {} ) {
 		global: {
 			provide: {
 				[ LanguageCodesProviderKey as symbol ]:
-					new ListLanguageCodesProvider( termLanguagesConfig ),
+					new MapLanguageCodesProvider( termLanguagesConfig ),
 				[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),
 			},
 		},
@@ -99,7 +99,7 @@ describe( 'SpellingVariantInput', () => {
 				global: {
 					provide: {
 						[ LanguageCodesProviderKey as symbol ]:
-							new ListLanguageCodesProvider( termLanguages ),
+							new MapLanguageCodesProvider( termLanguages ),
 						[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),
 					},
 				},

--- a/tests/unit/components/SpellingVariantInput.test.ts
+++ b/tests/unit/components/SpellingVariantInput.test.ts
@@ -3,7 +3,7 @@ import SpellingVariantInput from '@/components/SpellingVariantInput.vue';
 import { Lookup as WikitLookup } from '@wmde/wikit-vue-components';
 import { LanguageCodesProviderKey } from '@/plugins/LanguageCodesProviderPlugin/LanguageCodesProvider';
 
-const exampleWikibaseLexemeTermLanguagesConfig = [ 'en', 'en-ca', 'es', 'hi' ];
+const exampleWikibaseLexemeTermLanguagesConfig = [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ];
 
 function createLookup( config: Record<string, unknown> = {} ) {
 	return mount( SpellingVariantInput, {
@@ -33,7 +33,7 @@ describe( 'SpellingVariantInput', () => {
 			} );
 
 			expect( lookup.findComponent( WikitLookup ).props().value )
-				.toBe( exampleWikibaseLexemeTermLanguagesConfig[ selectedItemId ] );
+				.toStrictEqual( exampleWikibaseLexemeTermLanguagesConfig[ selectedItemId ] );
 		} );
 
 		it( ':menuItems - returned suggestions are provided to Wikit Lookup', async () => {
@@ -45,11 +45,13 @@ describe( 'SpellingVariantInput', () => {
 			expect( wikitLookup.props( 'menuItems' ) ).toStrictEqual( [
 				{
 					description: '',
-					label: 'en',
+					label: 'English (en)',
+					value: 'en',
 				},
 				{
 					description: '',
-					label: 'en-ca',
+					label: 'British English (en-gb)',
+					value: 'en-gb',
 				},
 			] );
 		} );
@@ -75,13 +77,14 @@ describe( 'SpellingVariantInput', () => {
 				{
 					label: exampleWikibaseLexemeTermLanguagesConfig[ selectedItemId ],
 					description: '',
+					value: 'en',
 				},
 			);
 
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore
 			expect( lookup.emitted( 'update:modelValue' )[ 1 ][ 0 ] )
-				.toBe( exampleWikibaseLexemeTermLanguagesConfig[ selectedItemId ] );
+				.toBe( 'en' );
 
 		} );
 	} );

--- a/tests/unit/components/SpellingVariantInput.test.ts
+++ b/tests/unit/components/SpellingVariantInput.test.ts
@@ -56,6 +56,61 @@ describe( 'SpellingVariantInput', () => {
 			] );
 		} );
 	} );
+
+	describe( 'suggested options', () => {
+		it.each( [
+			[
+				'Tun would open Tunisia',
+				[ [ 'en', 'English' ], [ 'aeb-latn', 'Tunisian Arabic (Latin script)' ], [ 'de', 'German' ] ],
+				'Tun',
+				[ 'aeb-latn' ],
+			],
+			[
+				'matching is not fuzzy - tsa does not match Tunisia',
+				[ [ 'en', 'English' ], [ 'aeb-latn', 'Tunisian Arabic (Latin script)' ], [ 'de', 'German' ] ],
+				'tsa',
+				[],
+			],
+			[
+				'Matching looks at each word in the list, i.e. Tunisian Arabic would display if arabic entered',
+				[ [ 'en', 'English' ], [ 'aeb-latn', 'Tunisian Arabic (Latin script)' ], [ 'de', 'German' ] ],
+				'arabic',
+				[ 'aeb-latn' ],
+			],
+			[
+				'Matching looks at each word in the list, i.e. Tunisian Arabic would display if arabic entered',
+				[ [ 'en', 'English' ], [ 'aeb-latn', 'Tunisian Arabic (Latin script)' ], [ 'de', 'German' ] ],
+				'aeb',
+				[ 'aeb-latn' ],
+			],
+			[
+				'shows all the languages that match the input',
+				[ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ],
+				'Engl',
+				[ 'en', 'en-gb' ],
+			],
+		] )( '%s', async ( _, totalOptions, userInput, expectedOptionValues ) => {
+			const lookup = mount( SpellingVariantInput, {
+				props: {
+					modelValue: '',
+				},
+				global: {
+					provide: {
+						[ LanguageCodesProviderKey as symbol ]: {
+							getLanguageCodes: () => totalOptions,
+						},
+					},
+				},
+			} );
+
+			await lookup.find( 'input' ).setValue( userInput );
+
+			const wikitLookup = lookup.getComponent( WikitLookup );
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			expect( wikitLookup.props( 'menuItems' ).map( ( option: any ) => option.value ) ).toStrictEqual( expectedOptionValues );
+		} );
+	} );
+
 	describe( '@events', () => {
 		it( '@update:modelValue - emits null when the input is changed', async () => {
 			const lookup = createLookup();

--- a/tests/unit/components/SpellingVariantInput.test.ts
+++ b/tests/unit/components/SpellingVariantInput.test.ts
@@ -78,7 +78,7 @@ describe( 'SpellingVariantInput', () => {
 				[ 'aeb-latn' ],
 			],
 			[
-				'Matching looks at each word in the list, i.e. Tunisian Arabic would display if arabic entered',
+				'Treats the language code as a word or words for the sake of matching',
 				[ [ 'en', 'English' ], [ 'aeb-latn', 'Tunisian Arabic (Latin script)' ], [ 'de', 'German' ] ],
 				'aeb',
 				[ 'aeb-latn' ],

--- a/tests/unit/components/SpellingVariantInput.test.ts
+++ b/tests/unit/components/SpellingVariantInput.test.ts
@@ -2,6 +2,8 @@ import { mount } from '@vue/test-utils';
 import SpellingVariantInput from '@/components/SpellingVariantInput.vue';
 import { Lookup as WikitLookup } from '@wmde/wikit-vue-components';
 import { LanguageCodesProviderKey } from '@/plugins/LanguageCodesProviderPlugin/LanguageCodesProvider';
+import DevMessagesRepository from '@/plugins/MessagesPlugin/DevMessagesRepository';
+import Messages, { MessagesKey } from '@/plugins/MessagesPlugin/Messages';
 
 const exampleWikibaseLexemeTermLanguagesConfig = [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ];
 
@@ -15,6 +17,7 @@ function createLookup( config: Record<string, unknown> = {} ) {
 				[ LanguageCodesProviderKey as symbol ]: {
 					getLanguageCodes: () => exampleWikibaseLexemeTermLanguagesConfig,
 				},
+				[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),
 			},
 		},
 		...config,
@@ -99,6 +102,7 @@ describe( 'SpellingVariantInput', () => {
 						[ LanguageCodesProviderKey as symbol ]: {
 							getLanguageCodes: () => totalOptions,
 						},
+						[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),
 					},
 				},
 			} );

--- a/tests/unit/components/SpellingVariantInput.test.ts
+++ b/tests/unit/components/SpellingVariantInput.test.ts
@@ -6,7 +6,7 @@ import DevMessagesRepository from '@/plugins/MessagesPlugin/DevMessagesRepositor
 import Messages, { MessagesKey } from '@/plugins/MessagesPlugin/Messages';
 import { ListLanguageCodesProvider } from '@/data-access/LanguageCodesProvider';
 
-const termLanguagesConfig = { en: 'English', 'en-gb': 'British English', de: 'German' };
+const termLanguagesConfig = new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
 
 function createLookup( config: Record<string, unknown> = {} ) {
 	return mount( SpellingVariantInput, {
@@ -63,35 +63,35 @@ describe( 'SpellingVariantInput', () => {
 		it.each( [
 			[
 				'Tun would open Tunisian',
-				{ en: 'English', 'aeb-latn': 'Tunisian Arabic (Latin script)', de: 'German' },
+				new Map( [ [ 'en', 'English' ], [ 'aeb-latn', 'Tunisian Arabic (Latin script)' ], [ 'de', 'German' ] ] ),
 				'Tun',
 				[ 'aeb-latn' ],
 			],
 			[
 				'matching is not fuzzy - tsa does not match Tunisian',
-				{ en: 'English', 'aeb-latn': 'Tunisian Arabic (Latin script)', de: 'German' },
+				new Map( [ [ 'en', 'English' ], [ 'aeb-latn', 'Tunisian Arabic (Latin script)' ], [ 'de', 'German' ] ] ),
 				'tsa',
 				[],
 			],
 			[
 				'Matching looks at each word in the list, i.e. Tunisian Arabic would display if arabic entered',
-				{ en: 'English', 'aeb-latn': 'Tunisian Arabic (Latin script)', de: 'German' },
+				new Map( [ [ 'en', 'English' ], [ 'aeb-latn', 'Tunisian Arabic (Latin script)' ], [ 'de', 'German' ] ] ),
 				'arabic',
 				[ 'aeb-latn' ],
 			],
 			[
 				'Treats the language code as a word or words for the sake of matching',
-				{ en: 'English', 'aeb-latn': 'Tunisian Arabic (Latin script)', de: 'German' },
+				new Map( [ [ 'en', 'English' ], [ 'aeb-latn', 'Tunisian Arabic (Latin script)' ], [ 'de', 'German' ] ] ),
 				'aeb',
 				[ 'aeb-latn' ],
 			],
 			[
 				'shows all the languages that match the input',
-				{ en: 'English', 'en-gb': 'British English', de: 'German' },
+				new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] ),
 				'Engl',
 				[ 'en', 'en-gb' ],
 			],
-		] )( '%s', async ( _, termLanguages: Record<string, string>, userInput, expectedOptionValues ) => {
+		] )( '%s', async ( _, termLanguages: Map<string, string>, userInput, expectedOptionValues ) => {
 			const lookup = mount( SpellingVariantInput, {
 				props: {
 					modelValue: '',

--- a/tests/unit/data-access/LangCodeProvider.test.ts
+++ b/tests/unit/data-access/LangCodeProvider.test.ts
@@ -25,9 +25,9 @@ describe( 'LanguageCodesProvider', () => {
 			const listOfValidCodes = { en: 'English', 'en-gb': 'British English', de: 'German' };
 			const sut = new ListLanguageCodesProvider( listOfValidCodes );
 
-			const actual = sut.getLanguageCodes();
+			const actual = sut.getLanguages();
 
-			expect( actual ).toStrictEqual( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
+			expect( actual ).toStrictEqual( new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] ) );
 		} );
 	} );
 } );

--- a/tests/unit/data-access/LangCodeProvider.test.ts
+++ b/tests/unit/data-access/LangCodeProvider.test.ts
@@ -3,7 +3,7 @@ import { ListLanguageCodesProvider } from '@/data-access/LanguageCodesProvider';
 describe( 'LanguageCodesProvider', () => {
 	describe( 'isValidLangCode', () => {
 		it( 'returns "true" for a valid language code', () => {
-			const listOfValidCodes = [ 'en', 'en-gb', 'de' ];
+			const listOfValidCodes = { en: 'English', 'en-gb': 'British English', de: 'German' };
 			const sut = new ListLanguageCodesProvider( listOfValidCodes );
 
 			const actual = sut.isValid( 'en-gb' );
@@ -11,12 +11,23 @@ describe( 'LanguageCodesProvider', () => {
 			expect( actual ).toBe( true );
 		} );
 		it( 'returns "false" for an invalid language code', () => {
-			const listOfValidCodes = [ 'en', 'en-gb', 'de' ];
+			const listOfValidCodes = { en: 'English', 'en-gb': 'British English', de: 'German' };
 			const sut = new ListLanguageCodesProvider( listOfValidCodes );
 
 			const actual = sut.isValid( 'raccoon' );
 
 			expect( actual ).toBe( false );
+		} );
+	} );
+
+	describe( 'getLanguageCodes', () => {
+		it( 'returns list of language codes and names', () => {
+			const listOfValidCodes = { en: 'English', 'en-gb': 'British English', de: 'German' };
+			const sut = new ListLanguageCodesProvider( listOfValidCodes );
+
+			const actual = sut.getLanguageCodes();
+
+			expect( actual ).toStrictEqual( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
 		} );
 	} );
 } );

--- a/tests/unit/data-access/LangCodeProvider.test.ts
+++ b/tests/unit/data-access/LangCodeProvider.test.ts
@@ -1,10 +1,10 @@
-import { ListLanguageCodesProvider } from '@/data-access/LanguageCodesProvider';
+import { MapLanguageCodesProvider } from '@/data-access/LanguageCodesProvider';
 
-describe( 'LanguageCodesProvider', () => {
+describe( 'MapLanguageCodesProvider', () => {
 	describe( 'isValidLangCode', () => {
 		it( 'returns "true" for a valid language code', () => {
 			const listOfValidCodes = new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
-			const sut = new ListLanguageCodesProvider( listOfValidCodes );
+			const sut = new MapLanguageCodesProvider( listOfValidCodes );
 
 			const actual = sut.isValid( 'en-gb' );
 
@@ -12,7 +12,7 @@ describe( 'LanguageCodesProvider', () => {
 		} );
 		it( 'returns "false" for an invalid language code', () => {
 			const listOfValidCodes = new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
-			const sut = new ListLanguageCodesProvider( listOfValidCodes );
+			const sut = new MapLanguageCodesProvider( listOfValidCodes );
 
 			const actual = sut.isValid( 'raccoon' );
 
@@ -23,7 +23,7 @@ describe( 'LanguageCodesProvider', () => {
 	describe( 'getLanguages', () => {
 		it( 'returns map of language codes and names', () => {
 			const listOfValidCodes = new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
-			const sut = new ListLanguageCodesProvider( listOfValidCodes );
+			const sut = new MapLanguageCodesProvider( listOfValidCodes );
 
 			const actual = sut.getLanguages();
 

--- a/tests/unit/data-access/LangCodeProvider.test.ts
+++ b/tests/unit/data-access/LangCodeProvider.test.ts
@@ -3,7 +3,7 @@ import { ListLanguageCodesProvider } from '@/data-access/LanguageCodesProvider';
 describe( 'LanguageCodesProvider', () => {
 	describe( 'isValidLangCode', () => {
 		it( 'returns "true" for a valid language code', () => {
-			const listOfValidCodes = { en: 'English', 'en-gb': 'British English', de: 'German' };
+			const listOfValidCodes = new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
 			const sut = new ListLanguageCodesProvider( listOfValidCodes );
 
 			const actual = sut.isValid( 'en-gb' );
@@ -11,7 +11,7 @@ describe( 'LanguageCodesProvider', () => {
 			expect( actual ).toBe( true );
 		} );
 		it( 'returns "false" for an invalid language code', () => {
-			const listOfValidCodes = { en: 'English', 'en-gb': 'British English', de: 'German' };
+			const listOfValidCodes = new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
 			const sut = new ListLanguageCodesProvider( listOfValidCodes );
 
 			const actual = sut.isValid( 'raccoon' );
@@ -22,7 +22,7 @@ describe( 'LanguageCodesProvider', () => {
 
 	describe( 'getLanguageCodes', () => {
 		it( 'returns list of language codes and names', () => {
-			const listOfValidCodes = { en: 'English', 'en-gb': 'British English', de: 'German' };
+			const listOfValidCodes = new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
 			const sut = new ListLanguageCodesProvider( listOfValidCodes );
 
 			const actual = sut.getLanguages();

--- a/tests/unit/data-access/LangCodeProvider.test.ts
+++ b/tests/unit/data-access/LangCodeProvider.test.ts
@@ -20,8 +20,8 @@ describe( 'LanguageCodesProvider', () => {
 		} );
 	} );
 
-	describe( 'getLanguageCodes', () => {
-		it( 'returns list of language codes and names', () => {
+	describe( 'getLanguages', () => {
+		it( 'returns map of language codes and names', () => {
 			const listOfValidCodes = new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
 			const sut = new ListLanguageCodesProvider( listOfValidCodes );
 

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -17,7 +17,7 @@ describe( 'createAndMount', () => {
 			rootSelector: '#test-app',
 			licenseUrl: '',
 			licenseName: '',
-			wikibaseLexemeTermLanguages: [ 'en' ],
+			wikibaseLexemeTermLanguages: { en: 'English', de: 'German' },
 		}, {
 			itemSearcher: unusedItemSearcher,
 			lexemeCreator: unusedLexemeCreator,

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -17,7 +17,10 @@ describe( 'createAndMount', () => {
 			rootSelector: '#test-app',
 			licenseUrl: '',
 			licenseName: '',
-			wikibaseLexemeTermLanguages: { en: 'English', de: 'German' },
+			wikibaseLexemeTermLanguages: new Map( [
+				[ 'en', 'English' ],
+				[ 'de', 'German' ],
+			] ),
 		}, {
 			itemSearcher: unusedItemSearcher,
 			lexemeCreator: unusedLexemeCreator,

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -198,7 +198,7 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			},
 			{
 				isValid: isValidMock,
-				getLanguageCodes: jest.fn(),
+				getLanguages: jest.fn(),
 			},
 		);
 
@@ -233,7 +233,7 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			},
 			{
 				isValid: isValidMock,
-				getLanguageCodes: jest.fn(),
+				getLanguages: jest.fn(),
 			},
 		);
 
@@ -271,7 +271,7 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			},
 			{
 				isValid: isValidMock,
-				getLanguageCodes: jest.fn(),
+				getLanguages: jest.fn(),
 			},
 		);
 


### PR DESCRIPTION
Todo:
* [x] more tests for filtering
* [x] better naming in LangCodeProvider?

Bug: T306515