### PR TITLE
Nicer copyright message in Dev/Staging view

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,8 @@
 
 			const config = {
 				rootSelector: '#app',
-				licenseUrl: '',
-				licenseName: '',
+				licenseUrl: 'https://creativecommons.org/publicdomain/zero/1.0/',
+				licenseName: 'Creative Commons CC0',
 				wikibaseLexemeTermLanguages: new Map([
 					[ 'en', 'English' ],
 					[ 'en-ca', 'Canadian English' ],

--- a/src/plugins/MessagesPlugin/DevMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/DevMessagesRepository.ts
@@ -18,7 +18,7 @@ const messages: Record<MessageKeys, string> = {
 	'wikibaselexeme-newlexeme-no-results': 'FIXME (copy is missing!)',
 	'wikibase-lexeme-lemma-language-option': '$1 ($2)',
 	'wikibase-shortcopyrightwarning': 'By clicking "$1", you agree to the [[$2|terms of use]], and you irrevocably agree to release your contribution under the [$3 $4].',
-	copyrightpage: '{{ns:project}}:Copyrights',
+	copyrightpage: 'Project:Copyrights',
 };
 
 /** Messages repository for the dev entry point. */


### PR DESCRIPTION
With #143 the dev message looks now a bit less nice in the dev/staging page because the `{` is double escaped rather than parsed. This fixes this by replacing it with a value that would plausibly be provided by `mw.msg` as well.