### PR TITLE
Don’t escape dev messages, only arguments

### DIFF
--- a/src/plugins/MessagesPlugin/DevMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/DevMessagesRepository.ts
@@ -17,7 +17,7 @@ const messages: Record<MessageKeys, string> = {
 	'wikibaselexeme-newlexeme-invalid-language-code-warning': 'This Item has an unrecognized language code. Please select one below.',
 	'wikibaselexeme-newlexeme-no-results': 'FIXME (copy is missing!)',
 	'wikibase-lexeme-lemma-language-option': '$1 ($2)',
-	'wikibase-shortcopyrightwarning': 'By clicking "$1", you agree to the [[$2|terms of use]], and you irrevocably agree to release your contribution under the [$3 $4].',
+	'wikibase-shortcopyrightwarning': 'By clicking "$1", you agree to the <a href="./$2">terms of use</a>, and you irrevocably agree to release your contribution under the <a href="$3">$4</a>.',
 	copyrightpage: 'Project:Copyrights',
 };
 
@@ -25,7 +25,7 @@ const messages: Record<MessageKeys, string> = {
 export default class DevMessagesRepository implements MessagesRepository {
 
 	public get( key: MessageKeys, ...params: string[] ): string {
-		return messages[ key ] !== undefined ? this.escape( this.replace( messages[ key ], ...params ) ) : `⧼${key}⧽`;
+		return messages[ key ] !== undefined ? this.replace( messages[ key ], ...params.map( this.escape ) ) : `⧼${key}⧽`;
 	}
 	public getText( key: MessageKeys, ...params: string[] ): string {
 		return messages[ key ] !== undefined ? this.replace( messages[ key ], ...params ) : `⧼${key}⧽`;

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -1,5 +1,5 @@
 import LanguageCodesProvider from '@/data-access/LanguageCodesProvider';
-import { ConfigKey } from '@/plugins/ConfigPlugin/Config';
+import { Config, ConfigKey } from '@/plugins/ConfigPlugin/Config';
 import { LanguageCodesProviderKey } from '@/plugins/LanguageCodesProviderPlugin/LanguageCodesProvider';
 import { mount } from '@vue/test-utils';
 import NewLexemeForm from '@/components/NewLexemeForm.vue';
@@ -26,12 +26,18 @@ describe( 'NewLexemeForm', () => {
 		} );
 	} );
 
+	const emptyConfig: Config = {
+		licenseUrl: '',
+		licenseName: '',
+		wikibaseLexemeTermLanguages: new Map(),
+	};
+
 	function mountForm() {
 		return mount( NewLexemeForm, {
 			global: {
 				plugins: [ store ],
 				provide: {
-					[ ConfigKey as symbol ]: {},
+					[ ConfigKey as symbol ]: emptyConfig,
 					[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ LanguageCodesProviderKey as symbol ]: unusedLanguageCodesProvider,
@@ -64,7 +70,7 @@ describe( 'NewLexemeForm', () => {
 			global: {
 				plugins: [ testStore ],
 				provide: {
-					[ ConfigKey as symbol ]: {},
+					[ ConfigKey as symbol ]: emptyConfig,
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ LanguageCodesProviderKey as symbol ]: {},
 					[ WikiRouterKey as symbol ]: null,
@@ -104,7 +110,7 @@ describe( 'NewLexemeForm', () => {
 			global: {
 				plugins: [ testStore ],
 				provide: {
-					[ ConfigKey as symbol ]: {},
+					[ ConfigKey as symbol ]: emptyConfig,
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ LanguageCodesProviderKey as symbol ]: languageCodesProvider,
 					[ WikiRouterKey as symbol ]: null,
@@ -148,7 +154,7 @@ describe( 'NewLexemeForm', () => {
 			global: {
 				plugins: [ testStore ],
 				provide: {
-					[ ConfigKey as symbol ]: {},
+					[ ConfigKey as symbol ]: emptyConfig,
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ LanguageCodesProviderKey as symbol ]: languageCodesProvider,
 					[ WikiRouterKey as symbol ]: null,
@@ -189,7 +195,7 @@ describe( 'NewLexemeForm', () => {
 			global: {
 				plugins: [ testStore ],
 				provide: {
-					[ ConfigKey as symbol ]: {},
+					[ ConfigKey as symbol ]: emptyConfig,
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ LanguageCodesProviderKey as symbol ]: {},
 					[ WikiRouterKey as symbol ]: { goToTitle },
@@ -229,7 +235,7 @@ describe( 'NewLexemeForm', () => {
 			global: {
 				plugins: [ testStore ],
 				provide: {
-					[ ConfigKey as symbol ]: {},
+					[ ConfigKey as symbol ]: emptyConfig,
 					[ ItemSearchKey as symbol ]: new DevItemSearcher(),
 					[ LanguageCodesProviderKey as symbol ]: {
 						getLanguages: () => new Map( [ [ 'en-gb', 'British English' ] ] ),


### PR DESCRIPTION
The messages themselves are hard-coded, we know they’re safe; this way, we can also make the links in the shortcopyrightwarning message work.

This means that the NewLexemeForm integration tests now need to supply a full config, otherwise `undefined` ends up being passed into the messages plugin, where it now causes an error.