### PR TITLE
Update netlify command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _**Prerequisits: This repository requires node v16 and up**_
 
 ### The first time you run a deploy
 
-To be able to run the netlify commands locally you will need to run `npx netlify login` once after `npm install` to authenticate and obtain a token.
+To be able to run the netlify commands locally you will need to run `npx -p netlify-cli netlify login` once after `npm install` to authenticate and obtain a token.
 
 ### Every time when doing a deploy
 


### PR DESCRIPTION
Since #45 (commit 6dc80b7b9d), we no longer include the `netlify-cli` package in our dependencies, so we need to tell `npx` where the `netlify` command comes from (compare the change to the `deployCommit` command in that commit).

Bug: T302321