### PR TITLE
Mostly downgrade required Node version from 16 to 14

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -10,7 +10,12 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: "16"
+                  node-version: "14"
+
+            - name: Setup NPM
+              run: npm install -g npm@8
+              # Node 14 (above) comes with NPM v6,
+              # which does not install peer dependencies that we need
 
             - name: Install Dependencies
               run: npm ci

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Please report bugs on [phabricator](https://phabricator.wikimedia.org/project/vi
 
 ## Local Development
 
-_**Prerequisites: This repository requires node v16 and up**_
+_**Prerequisites: This repository requires node v14+ and npm v7+**_
 
 1. Clone this repository
 2. Install dependecies with `npm i`

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
 				"vue-tsc": "^0.33.9"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=14"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 	},
 	"homepage": "https://github.com/wmde/new-lexeme-special-page#readme",
 	"engines": {
-		"node": ">=16"
+		"node": ">=14"
 	},
 	"dependencies": {
 		"@wmde/wikibase-datamodel-types": "^0.2.0",


### PR DESCRIPTION
As far as I can tell, the history of the Node requirement so far was:

1. bc365a6229 (#10): CI is added, running on Node 16 (then-current LTS); .nvmrc=16 is added at the same time, presumably for consistency
2. c2aa5b7773 (#16): Node 16 added to README, presumably based on .nvmrc
3. e0c53b713d (#55): Node 16 added to package.json, based on .nvmrc

So the Node version requirement gradually, and I think unintentionally, mutated from “let’s run CI on the latest software” into “we *need* the latest software”. But a full `npm cit` run still works under Node 14, and I think there is some value to supporting this version as well, as it’s currently the latest Node version supported by [Fresh][1]. So let’s change most of the Node 16 requirements to Node 14 instead.

However, we do need npm v7 or later: npm v6 does not install peer dependencies (even when they’re in the lockfile generated by a later npm version!), which means linting fails because some PostCSS packages (peer dependencies of the config we use) aren’t present. This isn’t a problem in fresh-node14, which comes with npm v7; however, upstream Node 14 ships npm v6, so our .nvmrc still needs to contain 16, not 14, and in CI (where we want to ensure compatibility with Node 14), we need to install a newer npm version explicitly.

[1]: https://github.com/wikimedia/fresh

Bug: T302321