### PR TITLE
Simplify ItemLookup code a bit

### DIFF
--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -51,9 +51,10 @@ const onOptionSelected = ( value: unknown ) => {
 	emit( 'update:modelValue', itemId );
 };
 
-const debouncedSearchForItems = ref(
-	null as null | DebouncedFunc<( debouncedInputValue: string ) => Promise<void>>,
-);
+const debouncedSearchForItems = debounce( async ( debouncedInputValue: string ) => {
+	const searchResults = await props.searchForItems( debouncedInputValue );
+	searchSuggestions.value = searchResults.map( searchResultToMonolingualOption );
+}, 150 );
 const searchInput = ref( '' );
 const onSearchInput = async ( inputValue: string ) => {
 	searchInput.value = inputValue;
@@ -65,13 +66,7 @@ const onSearchInput = async ( inputValue: string ) => {
 	if ( inputValue === lastSelectedOption.value?.label ) {
 		return;
 	}
-	if ( debouncedSearchForItems.value === null ) {
-		debouncedSearchForItems.value = debounce( async ( debouncedInputValue: string ) => {
-			const searchResults = await props.searchForItems( debouncedInputValue );
-			searchSuggestions.value = searchResults.map( searchResultToMonolingualOption );
-		}, 150 );
-	}
-	debouncedSearchForItems.value( inputValue );
+	debouncedSearchForItems( inputValue );
 };
 
 const onScroll = async () => {

--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -3,7 +3,6 @@ import { ref, computed } from 'vue';
 import { SearchedItemOption } from '@/data-access/ItemSearcher';
 import WikitLookup from './WikitLookup';
 import debounce from 'lodash/debounce';
-import { DebouncedFunc } from 'lodash';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 
 interface Props {


### PR DESCRIPTION
As far as I can tell, debouncedSearchForItems doesn’t need to be a ref, and I didn’t find any explanation for this in the comments of #78 either. Let’s try simplifying it…