### PR TITLE
Use new display section of wbsearchentities response

### DIFF
--- a/src/data-access/DevItemSearcher.ts
+++ b/src/data-access/DevItemSearcher.ts
@@ -42,7 +42,7 @@ export default class DevItemSearcher implements ItemSearcher {
 			origin: '*',
 		} ) ).then( ( r ) => r.json() ) as WbSearchEntitiesResponse;
 
-		return processResponse( response, 'en' );
+		return processResponse( response );
 	}
 
 }

--- a/src/data-access/MwApiItemSearcher.ts
+++ b/src/data-access/MwApiItemSearcher.ts
@@ -25,7 +25,7 @@ export default class MwApiItemSearcher implements ItemSearcher {
 			continue: offset,
 		} ) as WbSearchEntitiesResponse;
 
-		return processResponse( response, this.languageCode );
+		return processResponse( response );
 	}
 
 }

--- a/src/data-access/apiBasedItemSearcher.ts
+++ b/src/data-access/apiBasedItemSearcher.ts
@@ -13,35 +13,26 @@ export const commonParams: Record<string, string> = {
 export type WbSearchEntitiesResponse = {
 	search: {
 		id: string;
-		label?: string;
-		description?: string;
+		display: {
+			label?: {
+				language: string;
+				value: string;
+			};
+			description?: {
+				language: string;
+				value: string;
+			};
+		};
 	}[];
 };
 
 export function processResponse(
 	response: WbSearchEntitiesResponse,
-	defaultLanguageCode: string,
 ): SearchedItemOption[] {
-	return response.search.map( ( result ) => {
-		const option: SearchedItemOption = {
+	return response.search.map( ( result ): SearchedItemOption => {
+		return {
 			itemId: result.id,
-			display: {},
+			display: result.display,
 		};
-
-		if ( result.label ) {
-			option.display.label = {
-				language: defaultLanguageCode, // TODO T104344
-				value: result.label,
-			};
-		}
-
-		if ( result.description ) {
-			option.display.description = {
-				language: defaultLanguageCode, // TODO T104344
-				value: result.description,
-			};
-		}
-
-		return option;
 	} );
 }

--- a/tests/unit/data-access/MwApiItemSearcher.test.ts
+++ b/tests/unit/data-access/MwApiItemSearcher.test.ts
@@ -13,18 +13,24 @@ describe( 'MwApiItemSearcher', () => {
 				search: [
 					{
 						id: 'Q1',
-						label: 'Q1 label',
-						description: 'Q1 description',
+						display: {
+							label: { value: 'Q1 label', language: 'en' },
+							description: { value: 'Q1 description', language: 'en' },
+						},
 					},
 					{
 						id: 'Q2',
-						label: 'Q2 label',
-						// no description
+						display: {
+							label: { value: 'Q2 label', language: 'en' },
+							// no description
+						},
 					},
 					{
 						id: 'Q3',
-						// no label
-						description: 'Q3 description',
+						display: {
+							// no label
+							description: { value: 'Q3 description', language: 'en' },
+						},
 					},
 				],
 			} as WbSearchEntitiesResponse ),
@@ -71,6 +77,7 @@ describe( 'MwApiItemSearcher', () => {
 			get: jest.fn().mockResolvedValue( {
 				search: [ {
 					id: 'Q4',
+					display: {},
 				} ],
 			} ),
 		};


### PR DESCRIPTION
We don’t need to support old Wikibase versions, so now that the patches for T104344 have been merged for a few weeks, it should be fine to use the display field instead of the label and description fields. (Note that the display field is guaranteed to be present even when empty since wikimedia/Wikibase@4fec51a6b8 / change I2de40f965a), so one test case that was omitting it needs to be updated.)