### PR TITLE
Change ItemLookup error prop from optional to nullable

### DIFF
--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -10,9 +10,11 @@ interface Props {
 	placeholder: string;
 	value: string | null;
 	searchForItems: ( searchTerm: string, offset?: number ) => Promise<SearchedItemOption[]>;
-	error?: { type: 'error'|'warning'; message: string };
+	error: { type: 'error'|'warning'; message: string } | null;
 }
-const props = defineProps<Props>();
+const props = withDefaults( defineProps<Props>(), {
+	error: null,
+} );
 
 const emit = defineEmits( {
 	'update:modelValue': ( selectedItemId: string | null ) => {

--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -22,7 +22,7 @@ const store = useStore();
 
 const error = computed( () => {
 	if ( store.state.languageCodeFromLanguageItem !== false ) {
-		return undefined;
+		return null;
 	}
 	return {
 		type: 'warning' as const,


### PR DESCRIPTION
This seems to work better with eslint once we start using `withDefaults` (#176); with the previous code, `vue/require-default-prop` complains that “Prop 'error' requires default value to be set”.