### PR TITLE
Show suggested lexical categories in lookup

### DIFF
--- a/tests/unit/components/ItemLookup.test.ts
+++ b/tests/unit/components/ItemLookup.test.ts
@@ -144,7 +144,7 @@ describe( 'ItemLookup', () => {
 		} );
 
 		it( ':itemSuggestions - shows matching suggestions before search results', async () => {
-			const suggestedItems = [
+			const itemSuggestions = [
 				{
 					display: {
 						label: {
@@ -193,7 +193,7 @@ describe( 'ItemLookup', () => {
 					id: 'Q4',
 				},
 			] );
-			const lookup = createLookup( { searchForItems, suggestedItems } );
+			const lookup = createLookup( { searchForItems, itemSuggestions } );
 
 			await lookup.find( 'input' ).setValue( 'foo' );
 

--- a/tests/unit/components/ItemLookup.test.ts
+++ b/tests/unit/components/ItemLookup.test.ts
@@ -148,7 +148,7 @@ describe( 'ItemLookup', () => {
 				{
 					display: {
 						label: {
-							value: 'fool',
+							value: 'fool', // match
 							language: 'en',
 						},
 					},
@@ -157,7 +157,7 @@ describe( 'ItemLookup', () => {
 				{
 					display: {
 						label: {
-							value: 'bamboozle',
+							value: 'bamboozle', // does not match, should not be shown
 							language: 'en',
 						},
 					},
@@ -166,7 +166,7 @@ describe( 'ItemLookup', () => {
 				{
 					display: {
 						label: {
-							value: 'FOOD',
+							value: 'FOOD', // case-insensitive match
 							language: 'en',
 						},
 					},
@@ -192,6 +192,15 @@ describe( 'ItemLookup', () => {
 					},
 					id: 'Q4',
 				},
+				{
+					display: {
+						label: {
+							value: 'fool', // already in itemSuggestions, should not be shown again
+							language: 'en',
+						},
+					},
+					id: 'Q1',
+				},
 			] );
 			const lookup = createLookup( { searchForItems, itemSuggestions } );
 
@@ -199,6 +208,7 @@ describe( 'ItemLookup', () => {
 
 			const wikitLookup = lookup.getComponent( WikitLookup );
 			expect( wikitLookup.props( 'menuItems' ) ).toStrictEqual( [
+				// suggestions
 				{
 					description: '',
 					label: 'fool',
@@ -209,6 +219,7 @@ describe( 'ItemLookup', () => {
 					label: 'FOOD',
 					value: 'Q2',
 				},
+				// search results
 				{
 					description: '',
 					label: 'foo',
@@ -222,6 +233,7 @@ describe( 'ItemLookup', () => {
 			] );
 		} );
 	} );
+
 	describe( '@events', () => {
 		it( '@update:modelValue - emits null when the input is changed', async () => {
 			const searchForItems = jest.fn().mockReturnValue( exampleSearchResults );

--- a/tests/unit/components/ItemLookup.test.ts
+++ b/tests/unit/components/ItemLookup.test.ts
@@ -142,6 +142,85 @@ describe( 'ItemLookup', () => {
 				},
 			] );
 		} );
+
+		it( ':itemSuggestions - shows matching suggestions before search results', async () => {
+			const suggestedItems = [
+				{
+					display: {
+						label: {
+							value: 'fool',
+							language: 'en',
+						},
+					},
+					id: 'Q1',
+				},
+				{
+					display: {
+						label: {
+							value: 'bamboozle',
+							language: 'en',
+						},
+					},
+					id: 'Q11',
+				},
+				{
+					display: {
+						label: {
+							value: 'FOOD',
+							language: 'en',
+						},
+					},
+					id: 'Q2',
+				},
+			];
+			const searchForItems = jest.fn().mockReturnValue( [
+				{
+					display: {
+						label: {
+							value: 'foo',
+							language: 'en',
+						},
+					},
+					id: 'Q3',
+				},
+				{
+					display: {
+						label: {
+							value: 'bar',
+							language: 'en',
+						},
+					},
+					id: 'Q4',
+				},
+			] );
+			const lookup = createLookup( { searchForItems, suggestedItems } );
+
+			await lookup.find( 'input' ).setValue( 'foo' );
+
+			const wikitLookup = lookup.getComponent( WikitLookup );
+			expect( wikitLookup.props( 'menuItems' ) ).toStrictEqual( [
+				{
+					description: '',
+					label: 'fool',
+					value: 'Q1',
+				},
+				{
+					description: '',
+					label: 'FOOD',
+					value: 'Q2',
+				},
+				{
+					description: '',
+					label: 'foo',
+					value: 'Q3',
+				},
+				{
+					description: '',
+					label: 'bar',
+					value: 'Q4',
+				},
+			] );
+		} );
 	} );
 	describe( '@events', () => {
 		it( '@update:modelValue - emits null when the input is changed', async () => {


### PR DESCRIPTION
Show the matching suggested items as soon as possible, and prepend them to the search results, taking care not to repeat the items in the search results.

In this implementation, if the search results contain an item that is in the suggestions but was not matched by its label in the suggestions (e.g. an alias, or a label in another language), then that item will be ordered among the search results, not among the suggested items.

Bug: T298150