### PR TITLE
Add eslint-plugin-vuejs-accessibility

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
 		'@wmde/wikimedia-typescript',
 		'@vue/typescript/recommended',
 		'plugin:cypress/recommended',
+		'plugin:vuejs-accessibility/recommended',
 	],
 	rules: {
 		'comma-dangle': [ 'error', 'always-multiline' ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"eslint-config-wikimedia": "^0.22.1",
 				"eslint-plugin-cypress": "^2.12.1",
 				"eslint-plugin-vue": "^8.4.1",
+				"eslint-plugin-vuejs-accessibility": "^1.1.1",
 				"husky": "^7.0.4",
 				"jest": "^27.5.1",
 				"lint-staged": "^12.3.3",
@@ -2368,6 +2369,15 @@
 			"dev": true,
 			"dependencies": {
 				"sprintf-js": "~1.0.2"
+			}
+		},
+		"node_modules/aria-query": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+			"integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0"
 			}
 		},
 		"node_modules/array-differ": {
@@ -5085,6 +5095,26 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/eslint-plugin-vuejs-accessibility": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-1.1.1.tgz",
+			"integrity": "sha512-vmXfZQMlVLLhoEd9WWOzzhwLKRFVOnteSsrWD/DGvIMUDZ9MkwB3gQ+sdSpjqYMC+bb68BPsp3YpNZBzygp9Xg==",
+			"dev": true,
+			"dependencies": {
+				"aria-query": "^5.0.0",
+				"emoji-regex": "^10.0.0",
+				"vue-eslint-parser": "^8.0.0"
+			},
+			"peerDependencies": {
+				"eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/eslint-plugin-vuejs-accessibility/node_modules/emoji-regex": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
+			"integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==",
+			"dev": true
 		},
 		"node_modules/eslint-plugin-wdio": {
 			"version": "7.19.4",
@@ -14737,6 +14767,12 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"aria-query": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+			"integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+			"dev": true
+		},
 		"array-differ": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
@@ -16766,6 +16802,25 @@
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
+				}
+			}
+		},
+		"eslint-plugin-vuejs-accessibility": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-1.1.1.tgz",
+			"integrity": "sha512-vmXfZQMlVLLhoEd9WWOzzhwLKRFVOnteSsrWD/DGvIMUDZ9MkwB3gQ+sdSpjqYMC+bb68BPsp3YpNZBzygp9Xg==",
+			"dev": true,
+			"requires": {
+				"aria-query": "^5.0.0",
+				"emoji-regex": "^10.0.0",
+				"vue-eslint-parser": "^8.0.0"
+			},
+			"dependencies": {
+				"emoji-regex": {
+					"version": "10.1.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.1.0.tgz",
+					"integrity": "sha512-xAEnNCT3w2Tg6MA7ly6QqYJvEoY1tm9iIjJ3yMKK9JPlWuRHAMoe5iETwQnx3M9TVbFMfsrBgWKR+IsmswwNjg==",
+					"dev": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
 		"eslint-config-wikimedia": "^0.22.1",
 		"eslint-plugin-cypress": "^2.12.1",
 		"eslint-plugin-vue": "^8.4.1",
+		"eslint-plugin-vuejs-accessibility": "^1.1.1",
 		"husky": "^7.0.4",
 		"jest": "^27.5.1",
 		"lint-staged": "^12.3.3",


### PR DESCRIPTION
This doesn’t find any issues at the moment, but I’ve checked that it does something (if you add an `<img>` element without `alt=` attribute, it complains).

Bug: T307912