### PR TITLE
Add cypress-axe for accessibility testing

### DIFF
--- a/cypress/integration/NewLexemeForm.spec.js
+++ b/cypress/integration/NewLexemeForm.spec.js
@@ -22,9 +22,16 @@ function terminalLog( violations ) {
 
 describe( 'NewLexemeForm', () => {
 
-	it( 'submits form data with inferred language code', () => {
+	beforeEach( () => {
 		cy.visit( '/' );
+		cy.injectAxe();
+	} );
 
+	afterEach( () => {
+		cy.checkA11y( null, null, terminalLog );
+	} );
+
+	it( 'submits form data with inferred language code', () => {
 		cy.on( 'window:alert', cy.stub().as( 'alert' ) );
 
 		cy.intercept( { query: { action: 'wbgetclaims' } }, {
@@ -74,8 +81,6 @@ describe( 'NewLexemeForm', () => {
 	} );
 
 	it( 'submits form data with explicitly set spelling variant', () => {
-		cy.visit( '/' );
-
 		cy.on( 'window:alert', cy.stub().as( 'alert' ) );
 
 		cy.intercept( { query: { action: 'wbgetclaims' } }, {
@@ -110,12 +115,6 @@ describe( 'NewLexemeForm', () => {
 				'Navigating to: Special:EntityPage/L1',
 			);
 		} );
-	} );
-
-	it( 'should be accessible', () => {
-		cy.visit( '/' );
-		cy.injectAxe();
-		cy.checkA11y( null, null, terminalLog );
 	} );
 
 } );

--- a/cypress/integration/NewLexemeForm.spec.js
+++ b/cypress/integration/NewLexemeForm.spec.js
@@ -1,3 +1,5 @@
+import 'cypress-axe';
+
 describe( 'NewLexemeForm', () => {
 
 	it( 'submits form data with inferred language code', () => {
@@ -88,6 +90,12 @@ describe( 'NewLexemeForm', () => {
 				'Navigating to: Special:EntityPage/L1',
 			);
 		} );
+	} );
+
+	it( 'should be accessible', () => {
+		cy.visit( '/' );
+		cy.injectAxe();
+		cy.checkA11y();
 	} );
 
 } );

--- a/cypress/integration/NewLexemeForm.spec.js
+++ b/cypress/integration/NewLexemeForm.spec.js
@@ -1,5 +1,25 @@
 import 'cypress-axe';
 
+function terminalLog( violations ) {
+	cy.task(
+		'log',
+		`${violations.length} accessibility violation${
+			violations.length === 1 ? '' : 's'
+		} ${violations.length === 1 ? 'was' : 'were'} detected`,
+	);
+	// pluck specific keys to keep the table readable
+	const violationData = violations.map(
+		( { id, impact, description, nodes } ) => ( {
+			id,
+			impact,
+			description,
+			nodes: nodes.length,
+		} ),
+	);
+
+	cy.task( 'table', violationData );
+}
+
 describe( 'NewLexemeForm', () => {
 
 	it( 'submits form data with inferred language code', () => {
@@ -95,7 +115,7 @@ describe( 'NewLexemeForm', () => {
 	it( 'should be accessible', () => {
 		cy.visit( '/' );
 		cy.injectAxe();
-		cy.checkA11y();
+		cy.checkA11y( null, null, terminalLog );
 	} );
 
 } );

--- a/cypress/integration/NewLexemeForm.spec.js
+++ b/cypress/integration/NewLexemeForm.spec.js
@@ -20,6 +20,10 @@ function terminalLog( violations ) {
 	cy.task( 'table', violationData );
 }
 
+function checkA11y() {
+	cy.checkA11y( null, null, terminalLog );
+}
+
 describe( 'NewLexemeForm', () => {
 
 	beforeEach( () => {
@@ -28,7 +32,7 @@ describe( 'NewLexemeForm', () => {
 	} );
 
 	afterEach( () => {
-		cy.checkA11y( null, null, terminalLog );
+		checkA11y();
 	} );
 
 	it( 'submits form data with inferred language code', () => {
@@ -54,11 +58,14 @@ describe( 'NewLexemeForm', () => {
 			},
 		} ).as( 'LanguageCodeRetrieval' );
 
+		checkA11y();
+
 		cy.get( 'input[name=lemma]' )
 			.type( 'test lemma' );
 
 		cy.get( '.wbl-snl-language-lookup input' )
 			.type( '=Q123', { delay: 0 } );
+		checkA11y();
 		cy.get( '.wbl-snl-language-lookup .wikit-OptionsMenu__item' ).click();
 
 		cy.wait( '@LanguageCodeRetrieval' );

--- a/cypress/integration/NewLexemeForm.spec.js
+++ b/cypress/integration/NewLexemeForm.spec.js
@@ -20,8 +20,8 @@ function terminalLog( violations ) {
 	cy.task( 'table', violationData );
 }
 
-function checkA11y() {
-	cy.checkA11y( null, null, terminalLog );
+function checkA11y( context = null ) {
+	cy.checkA11y( context, null, terminalLog );
 }
 
 describe( 'NewLexemeForm', () => {
@@ -65,7 +65,7 @@ describe( 'NewLexemeForm', () => {
 
 		cy.get( '.wbl-snl-language-lookup input' )
 			.type( '=Q123', { delay: 0 } );
-		checkA11y();
+		checkA11y( '.wbl-snl-language-lookup' );
 		cy.get( '.wbl-snl-language-lookup .wikit-OptionsMenu__item' ).click();
 
 		cy.wait( '@LanguageCodeRetrieval' );

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -7,7 +7,7 @@
  * @type {Cypress.PluginConfig}
  */
 
-module.exports = ( on, config ) => {
+module.exports = ( on, _config ) => {
 	// `on` is used to hook into various events Cypress emits
 	// `config` is the resolved Cypress config
 	on( 'task', {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -7,10 +7,10 @@
  * @type {Cypress.PluginConfig}
  */
 
-module.exports = ( _on, _config ) => {
+module.exports = ( on, config ) => {
 	// `on` is used to hook into various events Cypress emits
 	// `config` is the resolved Cypress config
-	_on( 'task', {
+	on( 'task', {
 		log( message ) {
 			// eslint-disable-next-line no-console
 			console.log( message );

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -10,4 +10,18 @@
 module.exports = ( _on, _config ) => {
 	// `on` is used to hook into various events Cypress emits
 	// `config` is the resolved Cypress config
+	_on( 'task', {
+		log( message ) {
+			// eslint-disable-next-line no-console
+			console.log( message );
+
+			return null;
+		},
+		table( message ) {
+			// eslint-disable-next-line no-console
+			console.table( message );
+
+			return null;
+		},
+	} );
 };

--- a/index.html
+++ b/index.html
@@ -6,106 +6,109 @@
 		<title>New Lexeme</title>
 	</head>
 	<body>
-		<div id="wbl-snl-intro-text-wrapper"></div>
-		<div id="app"></div>
-		<script type="module">
-			import createAndMount from './src/main.ts';
-			import DevMessagesRepository from './src/plugins/MessagesPlugin/DevMessagesRepository';
-			import DevItemSearcher from './src/data-access/DevItemSearcher';
-			import DevLexemeCreator from './src/data-access/DevLexemeCreator';
-			import DevLangCodeRetriever from './src/data-access/DevLangCodeRetriever';
+		<main>
+			<h1>New Lexeme</h1>
+			<div id="wbl-snl-intro-text-wrapper"></div>
+			<div id="app"></div>
+			<script type="module">
+				import createAndMount from './src/main.ts';
+				import DevMessagesRepository from './src/plugins/MessagesPlugin/DevMessagesRepository';
+				import DevItemSearcher from './src/data-access/DevItemSearcher';
+				import DevLexemeCreator from './src/data-access/DevLexemeCreator';
+				import DevLangCodeRetriever from './src/data-access/DevLangCodeRetriever';
 
-			const config = {
-				rootSelector: '#app',
-				licenseUrl: 'https://creativecommons.org/publicdomain/zero/1.0/',
-				licenseName: 'Creative Commons CC0',
-				wikibaseLexemeTermLanguages: new Map([
-					[ 'en', 'English' ],
-					[ 'en-ca', 'Canadian English' ],
-					[ 'en-gb', 'British English' ],
-					[ 'enm', 'Middle English' ],
-					[ 'es', 'Spanish' ],
-					[ 'de', 'German' ],
-					[ 'aeb', 'Tunisian Arabic' ],
-					[ 'af', 'Afrikaans' ],
-					[ 'eo', 'Esperanto' ],
-					[ 'ha-arab', 'Hausa in Arab script' ]
-				]),
-				lexicalCategorySuggestions: [
-					{
-						id: 'Q1084',
-						display: {
-							label: {
-								language: 'en',
-								value: 'noun',
-							},
-							description: {
-								language: 'en',
-								value: 'part of speech in grammar denoting a figurative or real thing or person',
-							},
-						},
-					},
-					{
-						id: 'Q34698',
-						display: {
-							label: {
-								language: 'en',
-								value: 'adjective',
-							},
-							description: {
-								language: 'en',
-								value: 'part of speech that describes a noun or pronoun',
+				const config = {
+					rootSelector: '#app',
+					licenseUrl: 'https://creativecommons.org/publicdomain/zero/1.0/',
+					licenseName: 'Creative Commons CC0',
+					wikibaseLexemeTermLanguages: new Map([
+						[ 'en', 'English' ],
+						[ 'en-ca', 'Canadian English' ],
+						[ 'en-gb', 'British English' ],
+						[ 'enm', 'Middle English' ],
+						[ 'es', 'Spanish' ],
+						[ 'de', 'German' ],
+						[ 'aeb', 'Tunisian Arabic' ],
+						[ 'af', 'Afrikaans' ],
+						[ 'eo', 'Esperanto' ],
+						[ 'ha-arab', 'Hausa in Arab script' ]
+					]),
+					lexicalCategorySuggestions: [
+						{
+							id: 'Q1084',
+							display: {
+								label: {
+									language: 'en',
+									value: 'noun',
+								},
+								description: {
+									language: 'en',
+									value: 'part of speech in grammar denoting a figurative or real thing or person',
+								},
 							},
 						},
-					},
-					{
-						id: 'Q24905',
-						display: {
-							label: {
-								language: 'en',
-								value: 'verb',
-							},
-							description: {
-								language: 'en',
-								value: 'Lexical Category',
-							},
-						},
-					},
-					{
-						id: 'Q380057',
-						display: {
-							label: {
-								language: 'en',
-								value: 'adverb',
-							},
-							description: {
-								language: 'en',
-								value: 'word that modifies a verb, adjective, or another adverb',
+						{
+							id: 'Q34698',
+							display: {
+								label: {
+									language: 'en',
+									value: 'adjective',
+								},
+								description: {
+									language: 'en',
+									value: 'part of speech that describes a noun or pronoun',
+								},
 							},
 						},
+						{
+							id: 'Q24905',
+							display: {
+								label: {
+									language: 'en',
+									value: 'verb',
+								},
+								description: {
+									language: 'en',
+									value: 'Lexical Category',
+								},
+							},
+						},
+						{
+							id: 'Q380057',
+							display: {
+								label: {
+									language: 'en',
+									value: 'adverb',
+								},
+								description: {
+									language: 'en',
+									value: 'word that modifies a verb, adjective, or another adverb',
+								},
+							},
+						},
+					],
+				};
+				const services = {
+					itemSearcher: new DevItemSearcher(),
+					langCodeRetriever: new DevLangCodeRetriever(),
+					messagesRepository: new DevMessagesRepository(),
+					lexemeCreator: new DevLexemeCreator(),
+					searchLinker: {
+						getSearchUrlForLexeme( searchTerm ) {
+							const search = encodeURIComponent( searchTerm );
+							return `https://www.wikidata.org/w/index.php?search=${search}&ns146=1`;
+						},
 					},
-				],
-			};
-			const services = {
-				itemSearcher: new DevItemSearcher(),
-				langCodeRetriever: new DevLangCodeRetriever(),
-				messagesRepository: new DevMessagesRepository(),
-				lexemeCreator: new DevLexemeCreator(),
-				searchLinker: {
-					getSearchUrlForLexeme( searchTerm ) {
-						const search = encodeURIComponent( searchTerm );
-						return `https://www.wikidata.org/w/index.php?search=${search}&ns146=1`;
+					tracker: {
+						increment( name ) {
+							console.log( `TRACK: increment ${name}` );
+						},
 					},
-				},
-				tracker: {
-					increment( name ) {
-						console.log( `TRACK: increment ${name}` );
-					},
-				},
-				wikiRouter: { goToTitle( title ) { alert( `Navigating to: ${title}` ); } },
-			};
+					wikiRouter: { goToTitle( title ) { alert( `Navigating to: ${title}` ); } },
+				};
 
-			createAndMount( config, services );
-		</script>
+				createAndMount( config, services );
+			</script>
+		</main>
 	</body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"@vue/test-utils": "^2.0.0-rc.17",
 				"@vue/vue3-jest": "^27.0.0-alpha.4",
 				"@wmde/eslint-config-wikimedia-typescript": "^0.2.3",
+				"axe-core": "^4.4.1",
 				"cypress": "^9.4.1",
 				"cypress-axe": "^0.14.0",
 				"eslint": "^8.8.0",
@@ -2500,7 +2501,6 @@
 			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
 			"integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -14893,8 +14893,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
 			"integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"axios": {
 			"version": "0.21.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
 				"@vue/vue3-jest": "^27.0.0-alpha.4",
 				"@wmde/eslint-config-wikimedia-typescript": "^0.2.3",
 				"cypress": "^9.4.1",
+				"cypress-axe": "^0.14.0",
 				"eslint": "^8.8.0",
 				"eslint-config-wikimedia": "^0.22.1",
 				"eslint-plugin-cypress": "^2.12.1",
@@ -2494,6 +2495,16 @@
 			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
 			"dev": true
 		},
+		"node_modules/axe-core": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
+			"integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/axios": {
 			"version": "0.21.4",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -3501,6 +3512,19 @@
 			},
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/cypress-axe": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-0.14.0.tgz",
+			"integrity": "sha512-7Rdjnko0MjggCmndc1wECAkvQBIhuy+DRtjF7bd5YPZRFvubfMNvrxfqD8PWQmxm7MZE0ffS4Xr43V6ZmvLopg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"axe-core": "^3 || ^4",
+				"cypress": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
 			}
 		},
 		"node_modules/cypress/node_modules/@types/node": {
@@ -14865,6 +14889,13 @@
 			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
 			"dev": true
 		},
+		"axe-core": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
+			"integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw==",
+			"dev": true,
+			"peer": true
+		},
 		"axios": {
 			"version": "0.21.4",
 			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -15705,6 +15736,13 @@
 					}
 				}
 			}
+		},
+		"cypress-axe": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-0.14.0.tgz",
+			"integrity": "sha512-7Rdjnko0MjggCmndc1wECAkvQBIhuy+DRtjF7bd5YPZRFvubfMNvrxfqD8PWQmxm7MZE0ffS4Xr43V6ZmvLopg==",
+			"dev": true,
+			"requires": {}
 		},
 		"dashdash": {
 			"version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
 		"@vue/vue3-jest": "^27.0.0-alpha.4",
 		"@wmde/eslint-config-wikimedia-typescript": "^0.2.3",
 		"cypress": "^9.4.1",
+		"cypress-axe": "^0.14.0",
 		"eslint": "^8.8.0",
 		"eslint-config-wikimedia": "^0.22.1",
 		"eslint-plugin-cypress": "^2.12.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"@vue/test-utils": "^2.0.0-rc.17",
 		"@vue/vue3-jest": "^27.0.0-alpha.4",
 		"@wmde/eslint-config-wikimedia-typescript": "^0.2.3",
+		"axe-core": "^4.4.1",
 		"cypress": "^9.4.1",
 		"cypress-axe": "^0.14.0",
 		"eslint": "^8.8.0",


### PR DESCRIPTION
Add [cypress-axe](https://www.npmjs.com/package/cypress-axe) cypress-axe as our main CI accesibility testing tool.

Adding instructions on how to run the tests will be tackled on [T302321](https://phabricator.wikimedia.org/T302321)

`tput: No value for $TERM and no -T specified` warning showing in CI is a known bug and still an open issue in cypress.
https://github.com/cypress-io/cypress/issues/15679

Bug: [T307910](https://phabricator.wikimedia.org/T307910)