### PR TITLE
Remove chromeWebSecurity: false from cypress.json

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
 	"baseUrl": "http://localhost:3000/",
-	"chromeWebSecurity": false,
 	"supportFile": false
 }


### PR DESCRIPTION
No longer needed now that we don’t submit the form anymore.

This partially reverts commit e0c53b713d97eb17a7308861355692babbd63f7d.

Bug: T302961