### PR TITLE
Remove unused async keyword

### DIFF
--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -72,7 +72,7 @@ const debouncedSearchForItems = debounce( async ( debouncedInputValue: string ) 
 		.map( searchResultToMonolingualOption );
 }, 150 );
 const searchInput = ref( '' );
-const onSearchInput = async ( inputValue: string ) => {
+const onSearchInput = ( inputValue: string ) => {
 	searchInput.value = inputValue;
 	if ( inputValue.trim() === '' ) {
 		searchSuggestions.value = [];


### PR DESCRIPTION
This function doesn’t do anything asynchronously. (It *calls* an async function, debouncedSearchForItems, but doesn’t await it.)