### PR TITLE
Turn store language and lexicalCategory into SearchedItemOption

### DIFF
--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { SearchedItemOption } from '@/data-access/ItemSearcher';
 import { useStore } from 'vuex';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import ItemLookup from '@/components/ItemLookup.vue';
@@ -6,7 +7,7 @@ import { useItemSearch } from '@/plugins/ItemSearchPlugin/ItemSearch';
 import { computed } from 'vue';
 
 interface Props {
-	modelValue: string | null;
+	modelValue: SearchedItemOption | null;
 }
 
 defineProps<Props>();

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import ItemLookup from '@/components/ItemLookup.vue';
+import { SearchedItemOption } from '@/data-access/ItemSearcher';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import { useItemSearch } from '@/plugins/ItemSearchPlugin/ItemSearch';
 import { useConfig } from '@/plugins/ConfigPlugin/Config';
 
 interface Props {
-	modelValue: string | null;
+	modelValue: SearchedItemOption | null;
 }
 
 defineProps<Props>();

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { SearchedItemOption } from '@/data-access/ItemSearcher';
 import { CREATE_LEXEME, HANDLE_LANGUAGE_CHANGE } from '@/store/actions';
 import { computed } from 'vue';
 import { useStore } from 'vuex';
@@ -30,18 +31,18 @@ const lemma = computed( {
 	},
 } );
 const language = computed( {
-	get(): string {
+	get(): SearchedItemOption | null {
 		return store.state.language;
 	},
-	set( newLanguage: string ): void {
+	set( newLanguage: SearchedItemOption | null ): void {
 		store.commit( SET_LANGUAGE, newLanguage );
 	},
 } );
 const lexicalCategory = computed( {
-	get(): string {
+	get(): SearchedItemOption | null {
 		return store.state.lexicalCategory;
 	},
-	set( newLexicalCategory: string ): void {
+	set( newLexicalCategory: SearchedItemOption | null ): void {
 		store.commit( SET_LEXICAL_CATEGORY, newLexicalCategory );
 	},
 } );
@@ -89,8 +90,8 @@ const onSubmit = async () => {
 	}
 };
 
-const onLanguageSelect = async ( newLanguageId: string | null ) => {
-	await store.dispatch( HANDLE_LANGUAGE_CHANGE, newLanguageId );
+const onLanguageSelect = async ( newLanguage: SearchedItemOption | null ) => {
+	await store.dispatch( HANDLE_LANGUAGE_CHANGE, newLanguage );
 };
 
 </script>

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -1,3 +1,5 @@
+import { SearchedItemOption } from '@/data-access/ItemSearcher';
+
 export interface SubmitError {
 	type: string;
 	message?: string;
@@ -5,9 +7,9 @@ export interface SubmitError {
 
 export default interface RootState {
 	lemma: string;
-	language: string;
+	language: SearchedItemOption | null;
 	languageCodeFromLanguageItem: string | undefined | null | false;
-	lexicalCategory: string;
+	lexicalCategory: SearchedItemOption | null;
 	spellingVariant: string;
 	globalErrors: SubmitError[];
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -31,9 +31,9 @@ export default function initStore( {
 		state(): RootState {
 			return {
 				lemma: '',
-				language: '',
+				language: null,
 				languageCodeFromLanguageItem: undefined,
-				lexicalCategory: '',
+				lexicalCategory: null,
 				spellingVariant: '',
 				globalErrors: [],
 			};

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -6,6 +6,7 @@
  * @see https://vuex.vuejs.org/guide/structure.html
  */
 
+import { SearchedItemOption } from '@/data-access/ItemSearcher';
 import RootState, { SubmitError } from './RootState';
 
 export const SET_LEMMA = 'setLemma';
@@ -20,10 +21,10 @@ export default {
 	[ SET_LEMMA ]( state: RootState, lemma: string ): void {
 		state.lemma = lemma;
 	},
-	[ SET_LANGUAGE ]( state: RootState, language: string ): void {
+	[ SET_LANGUAGE ]( state: RootState, language: SearchedItemOption ): void {
 		state.language = language;
 	},
-	[ SET_LEXICAL_CATEGORY ]( state: RootState, lexicalCategory: string ): void {
+	[ SET_LEXICAL_CATEGORY ]( state: RootState, lexicalCategory: SearchedItemOption ): void {
 		state.lexicalCategory = lexicalCategory;
 	},
 	[ SET_SPELLING_VARIANT ]( state: RootState, spellingVariant: string ): void {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -21,10 +21,10 @@ export default {
 	[ SET_LEMMA ]( state: RootState, lemma: string ): void {
 		state.lemma = lemma;
 	},
-	[ SET_LANGUAGE ]( state: RootState, language: SearchedItemOption ): void {
+	[ SET_LANGUAGE ]( state: RootState, language: SearchedItemOption | null ): void {
 		state.language = language;
 	},
-	[ SET_LEXICAL_CATEGORY ]( state: RootState, lexicalCategory: SearchedItemOption ): void {
+	[ SET_LEXICAL_CATEGORY ]( state: RootState, lexicalCategory: SearchedItemOption | null ): void {
 		state.lexicalCategory = lexicalCategory;
 	},
 	[ SET_SPELLING_VARIANT ]( state: RootState, spellingVariant: string ): void {

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -88,7 +88,7 @@ describe( 'NewLexemeForm', () => {
 		await wrapper.find( '.wbl-snl-language-lookup .wikit-OptionsMenu__item' ).trigger( 'click' );
 
 		expect( wrapper.find( '.wbl-snl-spelling-variant-lookup' ).exists() ).toBe( false );
-		expect( testStore.state.language ).toBe( 'Q123' );
+		expect( testStore.state.language?.id ).toBe( 'Q123' );
 		expect( testStore.state.languageCodeFromLanguageItem ).toBe( 'de' );
 
 		await languageLookup.setValue( '=Q12' );
@@ -141,7 +141,7 @@ describe( 'NewLexemeForm', () => {
 		await lexicalCategoryInput.setValue( '=Q456' );
 		await wrapper.find( '.wbl-snl-lexical-category-lookup .wikit-OptionsMenu__item' ).trigger( 'click' );
 
-		expect( store.state.lexicalCategory ).toBe( 'Q456' );
+		expect( store.state.lexicalCategory?.id ).toBe( 'Q456' );
 	} );
 
 	it( 'updates the store if a language is selected in the spelling variant input', async () => {

--- a/tests/unit/components/ItemLookup.test.ts
+++ b/tests/unit/components/ItemLookup.test.ts
@@ -100,13 +100,13 @@ describe( 'ItemLookup', () => {
 			expect( searchForItems ).toHaveBeenNthCalledWith( 2, 'foo', 4 );
 		} );
 
-		it( ':value - selects the selected Item with this QID', async () => {
+		it( ':value - selects the given Item', async () => {
 			const searchForItems = jest.fn().mockReturnValue( exampleSearchResults );
 			const lookup = createLookup( { searchForItems } );
 			await lookup.find( 'input' ).setValue( 'foo' );
 			const selectedItemId = 1;
 
-			await lookup.setProps( { value: exampleSearchResults[ selectedItemId ].id } );
+			await lookup.setProps( { value: exampleSearchResults[ selectedItemId ] } );
 
 			expect( lookup.findComponent( WikitLookup ).props().value.label )
 				.toBe( exampleSearchResults[ selectedItemId ].display.label?.value );
@@ -246,7 +246,7 @@ describe( 'ItemLookup', () => {
 			expect( lookup.emitted( 'update:modelValue' )[ 0 ][ 0 ] ).toBe( null );
 		} );
 
-		it( '@update:modelValue - emits the itemId of the selected option', async () => {
+		it( '@update:modelValue - emits the search result of the selected option', async () => {
 			const searchForItems = jest.fn().mockReturnValue( exampleSearchResults );
 			const lookup = createLookup( { searchForItems } );
 			await lookup.find( 'input' ).setValue( 'foo' );
@@ -263,7 +263,7 @@ describe( 'ItemLookup', () => {
 
 			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 			// @ts-ignore
-			expect( lookup.emitted( 'update:modelValue' )[ 1 ][ 0 ] ).toBe( exampleSearchResults[ selectedItemId ].id );
+			expect( lookup.emitted( 'update:modelValue' )[ 1 ][ 0 ] ).toStrictEqual( exampleSearchResults[ selectedItemId ] );
 
 		} );
 	} );

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -34,8 +34,8 @@ describe( CREATE_LEXEME, () => {
 				return {
 					lemma: 'foo',
 					spellingVariant: '',
-					language: 'Q123',
-					lexicalCategory: 'Q234',
+					language: { id: 'Q123', display: {} },
+					lexicalCategory: { id: 'Q234', display: {} },
 					languageCodeFromLanguageItem: 'fr',
 				} as RootState;
 			},
@@ -75,8 +75,8 @@ describe( CREATE_LEXEME, () => {
 				return {
 					lemma: 'foo',
 					spellingVariant: 'de',
-					language: 'Q123',
-					lexicalCategory: 'Q234',
+					language: { id: 'Q123', display: {} },
+					lexicalCategory: { id: 'Q234', display: {} },
 					languageCodeFromLanguageItem: null,
 				} as RootState;
 			},
@@ -120,8 +120,8 @@ describe( CREATE_LEXEME, () => {
 			state(): RootState {
 				return {
 					lemma: 'foo',
-					language: 'Q123',
-					lexicalCategory: 'Q234',
+					language: { id: 'Q123', display: {} },
+					lexicalCategory: { id: 'Q234', display: {} },
 					spellingVariant: 'en',
 				} as RootState;
 			},
@@ -155,8 +155,8 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			state(): RootState {
 				return {
 					lemma: 'foo',
-					language: 'Q123',
-					lexicalCategory: 'Q234',
+					language: { id: 'Q123', display: {} },
+					lexicalCategory: { id: 'Q234', display: {} },
 					spellingVariant: 'bar',
 					languageCodeFromLanguageItem: false,
 				} as RootState;
@@ -165,9 +165,9 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			mutations,
 		} );
 
-		const actionPromise = store.dispatch( HANDLE_LANGUAGE_CHANGE, 'Q456' );
+		const actionPromise = store.dispatch( HANDLE_LANGUAGE_CHANGE, { id: 'Q456' } );
 
-		expect( store.state.language ).toBe( 'Q456' );
+		expect( store.state.language ).toStrictEqual( { id: 'Q456' } );
 		expect( store.state.spellingVariant ).toBe( '' );
 		expect( store.state.languageCodeFromLanguageItem ).toBe( undefined );
 
@@ -189,8 +189,8 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			state(): RootState {
 				return {
 					lemma: 'foo',
-					language: 'Q123',
-					lexicalCategory: 'Q234',
+					language: { id: 'Q123', display: {} },
+					lexicalCategory: { id: 'Q234', display: {} },
 					spellingVariant: 'bar',
 					languageCodeFromLanguageItem: false,
 				} as RootState;
@@ -205,11 +205,12 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 	} );
 
 	it( 'validates and sets to state if valid lang code was returned', async () => {
+		const getLanguageCodeFromItemMock = jest.fn().mockResolvedValue( 'de' );
 		const isValidMock = jest.fn().mockReturnValue( true );
 		const actions = createActions(
 			unusedLexemeCreator,
 			{
-				getLanguageCodeFromItem: jest.fn().mockResolvedValue( 'de' ),
+				getLanguageCodeFromItem: getLanguageCodeFromItemMock,
 			},
 			{
 				isValid: isValidMock,
@@ -222,8 +223,8 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			state(): RootState {
 				return {
 					lemma: 'foo',
-					language: 'Q123',
-					lexicalCategory: 'Q234',
+					language: { id: 'Q123', display: {} },
+					lexicalCategory: { id: 'Q234', display: {} },
 					spellingVariant: 'bar',
 					languageCodeFromLanguageItem: false,
 				} as RootState;
@@ -232,11 +233,12 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			mutations,
 		} );
 
-		await store.dispatch( HANDLE_LANGUAGE_CHANGE, 'Q456' );
+		await store.dispatch( HANDLE_LANGUAGE_CHANGE, { id: 'Q456' } );
 
-		expect( store.state.language ).toBe( 'Q456' );
+		expect( store.state.language ).toStrictEqual( { id: 'Q456' } );
 		expect( store.state.spellingVariant ).toBe( '' );
 		expect( store.state.languageCodeFromLanguageItem ).toBe( 'de' );
+		expect( getLanguageCodeFromItemMock ).toHaveBeenCalledWith( 'Q456' );
 		expect( isValidMock ).toHaveBeenCalledWith( 'de' );
 	} );
 
@@ -258,8 +260,8 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			state(): RootState {
 				return {
 					lemma: 'foo',
-					language: 'Q123',
-					lexicalCategory: 'Q234',
+					language: { id: 'Q123', display: {} },
+					lexicalCategory: { id: 'Q234', display: {} },
 					spellingVariant: 'bar',
 					languageCodeFromLanguageItem: false,
 				} as RootState;
@@ -268,9 +270,9 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			mutations,
 		} );
 
-		await store.dispatch( HANDLE_LANGUAGE_CHANGE, 'Q456' );
+		await store.dispatch( HANDLE_LANGUAGE_CHANGE, { id: 'Q456' } );
 
-		expect( store.state.language ).toBe( 'Q456' );
+		expect( store.state.language ).toStrictEqual( { id: 'Q456' } );
 		expect( store.state.spellingVariant ).toBe( '' );
 		expect( store.state.languageCodeFromLanguageItem ).toBe( false );
 		expect( isValidMock ).toHaveBeenCalledWith( 'vandalism' );
@@ -297,8 +299,8 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			state(): RootState {
 				return {
 					lemma: 'foo',
-					language: 'Q123',
-					lexicalCategory: 'Q234',
+					language: { id: 'Q123', display: {} },
+					lexicalCategory: { id: 'Q234', display: {} },
 					spellingVariant: 'bar',
 					languageCodeFromLanguageItem: false,
 				} as RootState;
@@ -307,9 +309,9 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 			mutations,
 		} );
 
-		await store.dispatch( HANDLE_LANGUAGE_CHANGE, 'Q456' );
+		await store.dispatch( HANDLE_LANGUAGE_CHANGE, { id: 'Q456' } );
 
-		expect( store.state.language ).toBe( 'Q456' );
+		expect( store.state.language ).toStrictEqual( { id: 'Q456' } );
 		expect( store.state.spellingVariant ).toBe( '' );
 		expect( store.state.languageCodeFromLanguageItem ).toBe( retrievedLangCodeResult );
 		expect( isValidMock ).not.toHaveBeenCalled();


### PR DESCRIPTION
Change the value prop of the `ItemLookup`, `LanguageInput` and `LexicalCategoryInput` components from a string (item ID) to a full `SearchedItemOption` object, and also change the type in the store, so that we use these objects (with an id, but also a display section) throughout. This will let us populate the lookups from the URL parameters.

Note that ItemLookup doesn’t fully react to incoming changes to the value prop yet, that will come later.

Bug: T308118