### PR TITLE
Make ItemLookup more useful when given non-null value

### DIFF
--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import {
+	computed,
+	ref,
+	watchEffect,
+} from 'vue';
 import { SearchedItemOption } from '@/data-access/ItemSearcher';
 import WikitLookup from './WikitLookup';
 import debounce from 'lodash/debounce';
@@ -26,6 +30,11 @@ const emit = defineEmits( {
 } );
 
 const searchInput = ref( '' );
+watchEffect( () => {
+	if ( props.value ) {
+		searchInput.value = props.value.display.label?.value ?? props.value.id;
+	}
+} );
 
 // itemSuggestions matching the current searchInput
 const suggestedOptions = computed( () => {
@@ -37,14 +46,20 @@ const suggestedOptions = computed( () => {
 // searchForItems() results for the current searchInput
 const searchedOptions = ref( [] as SearchedItemOption[] );
 
-const menuItems = computed( (): SearchedItemOption[] => [
-	...suggestedOptions.value,
-	...searchedOptions.value.filter(
-		( searchedOption ) => !suggestedOptions.value.some(
-			( suggestedOption ) => suggestedOption.id === searchedOption.id,
+const menuItems = computed( (): SearchedItemOption[] => {
+	const items = [
+		...suggestedOptions.value,
+		...searchedOptions.value.filter(
+			( searchedOption ) => !suggestedOptions.value.some(
+				( suggestedOption ) => suggestedOption.id === searchedOption.id,
+			),
 		),
-	),
-] );
+	];
+	if ( !items.length && props.value ) {
+		items.push( props.value );
+	}
+	return items;
+} );
 
 // `lastSelectedOption` is needed to prevent search for new options when one was just selected
 // by the user and thus the input updated to display the label of the selected option. This should

--- a/tests/unit/components/ItemLookup.test.ts
+++ b/tests/unit/components/ItemLookup.test.ts
@@ -112,6 +112,43 @@ describe( 'ItemLookup', () => {
 				.toBe( exampleSearchResults[ selectedItemId ].display.label?.value );
 		} );
 
+		it( ':value - sets the search input', async () => {
+			const lookup = createLookup( { value: {
+				id: 'Q1',
+				display: {
+					label: { language: 'en', value: 'some label' },
+				},
+			} } );
+			expect( lookup.findComponent( WikitLookup ).props().searchInput )
+				.toBe( 'some label' );
+
+			await lookup.setProps( { value: { id: 'Q2', display: {} } } );
+			expect( lookup.findComponent( WikitLookup ).props().searchInput )
+				.toBe( 'Q2' );
+		} );
+
+		it( ':value - provides a menu item', async () => {
+			const searchForItems = jest.fn();
+			const lookup = createLookup( {
+				value: {
+					id: 'Q1',
+					display: {
+						label: { language: 'en', value: 'some label' },
+						description: { language: 'en', value: 'some description' },
+					},
+				},
+				searchForItems,
+			} );
+
+			expect( lookup.findComponent( WikitLookup ).props().menuItems )
+				.toStrictEqual( [ {
+					value: 'Q1',
+					label: 'some label',
+					description: 'some description',
+				} ] );
+			expect( searchForItems ).not.toHaveBeenCalled();
+		} );
+
 		it( ':searchForItems - returned suggestions are provided to Wikit Lookup', async () => {
 			const searchForItems = jest.fn().mockReturnValue( exampleSearchResults );
 			const lookup = createLookup( { searchForItems } );


### PR DESCRIPTION
If the value is changed from outside (e.g. when we load the language or lexical category from URL parameters), it should be shown in the search input as well, and when users click the input, there should be at least one menu item rather than the “no results” message.

Bug: T308118