### PR TITLE
Use spelling variant over language code from language item

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -63,7 +63,7 @@ export default function createActions(
 			}
 			commit( CLEAR_ERRORS );
 			try {
-				const spellingVariant = state.languageCodeFromLanguageItem || state.spellingVariant;
+				const spellingVariant = state.spellingVariant || state.languageCodeFromLanguageItem || '';
 				const lexemeId = await lexemeCreator.createLexeme(
 					state.lemma,
 					spellingVariant,

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -78,10 +78,10 @@ describe( CREATE_LEXEME, () => {
 			state(): RootState {
 				return {
 					lemma: 'foo',
-					spellingVariant: 'de',
+					spellingVariant: 'de-formal',
 					language: { id: 'Q123', display: {} },
 					lexicalCategory: { id: 'Q234', display: {} },
-					languageCodeFromLanguageItem: null,
+					languageCodeFromLanguageItem: 'de',
 				} as RootState;
 			},
 			actions,
@@ -89,13 +89,16 @@ describe( CREATE_LEXEME, () => {
 				[ CLEAR_ERRORS ]: jest.fn(),
 			},
 		} );
+		// normally, spellingVariant would only be set if languageCodeFromLanguageItem is null;
+		// however, via the URL parameters one can set both at the same time,
+		// in which case the spellingVariant should take precedence
 
 		const lexemeId = await store.dispatch( CREATE_LEXEME );
 
 		expect( lexemeId ).toBe( 'L123' );
 		expect( lexemeCreator.createLexeme ).toHaveBeenCalledWith(
 			'foo',
-			'de',
+			'de-formal',
 			'Q123',
 			'Q234',
 		);


### PR DESCRIPTION
Usually, at most one of these will be set to a truthy value: as soon as a language is selected, the spelling variant is cleared, and the input with which the user can change it again is only shown once the language code from the language item is known to not exist. However, when we load parameters from the URL, it is possible to set both at the same time; in this case, the spelling variant should be used over the language code from the language item (assuming the user submits the form without changing the language – otherwise, the spelling variant will be cleared again).

A final fallback to '' is necessary because, unlike the spelling variant, the language code from language item may not be a string; falling back to the empty string matches the previous behavior.

Bug: T298154