### PR TITLE
Make ItemLookup error prop optional

### DIFF
--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -15,7 +15,7 @@ interface Props {
 	placeholder: string;
 	value: SearchedItemOption | null;
 	searchForItems: ( searchTerm: string, offset?: number ) => Promise<SearchedItemOption[]>;
-	error: { type: 'error'|'warning'; message: string } | null;
+	error?: { type: 'error'|'warning'; message: string } | null;
 	itemSuggestions?: SearchedItemOption[];
 }
 const props = withDefaults( defineProps<Props>(), {


### PR DESCRIPTION
Apparently this is necessary to avoid warnings in debug mode:

> ```
> [Vue warn]: Missing required prop: "error"
>   at <ItemLookup label="Lexical category" placeholder="The Lexeme's category, e.g. 'verb'" value=null  ... >
>   at <LexicalCategoryInput modelValue=null onUpdate:modelValue=fn >
>   at <NewLexemeForm>
>   at <App>
> ```

---

Follows-up #177, which was apparently not quite right.