### PR TITLE
Don't HTML-require the Lemma input

### DIFF
--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -50,7 +50,7 @@ export default {
 			exampleLemma
 		)"
 		name="lemma"
-		required
+		aria-required="true"
 		:error="buildError( error )"
 		:value="modelValue"
 		@input="$emit( 'update:modelValue', $event )"


### PR DESCRIPTION
The browser's own validation mechanisms are notoriously inaccessible and almost impossible to style. While they were nice during development. We can use something better in production.

Bug: T308660