### PR TITLE
Change submit button while creating Lexeme

### DIFF
--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { SearchedItemOption } from '@/data-access/ItemSearcher';
 import { CREATE_LEXEME, HANDLE_LANGUAGE_CHANGE } from '@/store/actions';
-import { computed } from 'vue';
+import {
+	computed,
+	ref,
+} from 'vue';
 import { useStore } from 'vuex';
 import { Button as WikitButton } from '@wmde/wikit-vue-components';
 import { useConfig } from '@/plugins/ConfigPlugin/Config';
@@ -58,7 +61,11 @@ const spellingVariant = computed( {
 		store.commit( SET_SPELLING_VARIANT, newSpellingVariant );
 	},
 } );
+
+const submitting = ref( false );
+
 const submitMsg = $messages.getUnescaped( 'wikibaselexeme-newlexeme-submit' );
+const submittingMsg = $messages.getUnescaped( 'wikibaselexeme-newlexeme-submitting' );
 const termsOfUseTitle = $messages.get( 'copyrightpage' );
 const copyrightText = $messages.get(
 	'wikibase-shortcopyrightwarning',
@@ -67,6 +74,9 @@ const copyrightText = $messages.get(
 	config.licenseUrl,
 	config.licenseName,
 );
+const submitButtonText = computed( () => {
+	return submitting.value ? submittingMsg : submitMsg;
+} );
 
 const error = computed( () => {
 	if ( store.state.globalErrors.length > 0 ) {
@@ -82,12 +92,14 @@ const error = computed( () => {
 } );
 const wikiRouter = useWikiRouter();
 const onSubmit = async () => {
+	submitting.value = true;
 	try {
 		const lexemeId = await store.dispatch( CREATE_LEXEME );
 		wikiRouter.goToTitle( `Special:EntityPage/${lexemeId}` );
 	} catch {
 		// Error is already in store and handled by ErrorMessage component
 	}
+	submitting.value = false;
 };
 
 const onLanguageSelect = async ( newLanguage: SearchedItemOption | null ) => {
@@ -132,8 +144,9 @@ export default {
 				type="progressive"
 				variant="primary"
 				native-type="submit"
+				:disabled="submitting"
 			>
-				{{ submitMsg }}
+				{{ submitButtonText }}
 			</wikit-button>
 		</div>
 	</form>

--- a/src/plugins/MessagesPlugin/DevMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/DevMessagesRepository.ts
@@ -13,6 +13,7 @@ const messages: Record<MessageKeys, string> = {
 	'wikibaselexeme-newlexeme-search-existing': 'You can check whether a Lexeme already exists by using <a href="$1">the search</a>. You can also learn more about Lexemes in the help box below.',
 	'wikibaselexeme-newlexeme-submit': 'Create Lexeme',
 	'wikibaselexeme-newlexeme-submit-error': 'The server encountered a temporary error and could not complete your request. Please try again.',
+	'wikibaselexeme-newlexeme-submitting': 'Creating Lexeme...',
 	'wikibaselexeme-newlexeme-error-no-lemma': 'Lemma field is empty, please make an entry.',
 	'wikibaselexeme-newlexeme-error-lemma-is-too-long': 'FIXME (copy is missing!)',
 	'wikibaselexeme-newlexeme-invalid-language-code-warning': 'This Item has an unrecognized language code. Please select one below.',

--- a/src/plugins/MessagesPlugin/MessageKeys.ts
+++ b/src/plugins/MessagesPlugin/MessageKeys.ts
@@ -10,6 +10,7 @@ type MessageKeys
  | 'wikibaselexeme-newlexeme-search-existing'
  | 'wikibaselexeme-newlexeme-submit'
  | 'wikibaselexeme-newlexeme-submit-error'
+ | 'wikibaselexeme-newlexeme-submitting'
  | 'wikibaselexeme-newlexeme-error-no-lemma'
  | 'wikibaselexeme-newlexeme-error-lemma-is-too-long'
  | 'wikibaselexeme-newlexeme-invalid-language-code-warning'

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -1,7 +1,7 @@
 import LanguageCodesProvider from '@/data-access/LanguageCodesProvider';
 import { Config, ConfigKey } from '@/plugins/ConfigPlugin/Config';
 import { LanguageCodesProviderKey } from '@/plugins/LanguageCodesProviderPlugin/LanguageCodesProvider';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import NewLexemeForm from '@/components/NewLexemeForm.vue';
 import initStore from '@/store';
 import unusedLexemeCreator from '../mocks/unusedLexemeCreator';
@@ -336,12 +336,7 @@ describe( 'NewLexemeForm', () => {
 			expect( submitButton.text() ).toBe( 'Creating Lexeme...' );
 
 			reject( [ { type: 'test', message: 'error' } ] );
-			await wrapper.vm.$nextTick();
-			await wrapper.vm.$nextTick();
-			await wrapper.vm.$nextTick();
-			await wrapper.vm.$nextTick();
-			await wrapper.vm.$nextTick();
-			await wrapper.vm.$nextTick();
+			await flushPromises();
 
 			expect( submitButton.attributes( 'disabled' ) ).toBe( undefined );
 			expect( submitButton.text() ).toBe( 'Create Lexeme' );

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -287,7 +287,7 @@ describe( 'NewLexemeForm', () => {
 		} );
 
 		it( 'disables button when submitting and reenables on error', async () => {
-			let reject = undefined as unknown as ( reason: any ) => void;
+			let reject = undefined as unknown as ( reason: unknown ) => void;
 			const promise = new Promise( ( _, reject_ ) => {
 				reject = reject_;
 			} );

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -286,6 +286,68 @@ describe( 'NewLexemeForm', () => {
 			expect( goToTitle ).toHaveBeenCalledWith( 'Special:EntityPage/L123' );
 		} );
 
+		it( 'disables button when submitting and reenables on error', async () => {
+			let reject = undefined as unknown as ( reason: any ) => void;
+			const promise = new Promise( ( _, reject_ ) => {
+				reject = reject_;
+			} );
+			const createLexeme = jest.fn().mockReturnValue( promise );
+			const goToTitle = jest.fn();
+			const testStore = initStore( {
+				lexemeCreator: { createLexeme },
+				langCodeRetriever: { getLanguageCodeFromItem: jest.fn().mockResolvedValue( 'de' ) },
+				languageCodesProvider: {
+					isValid: jest.fn().mockReturnValue( true ),
+					getLanguages: jest.fn(),
+				},
+				tracker: { increment: jest.fn() },
+			} );
+			const wrapper = mount( NewLexemeForm, {
+				global: {
+					plugins: [ testStore ],
+					provide: {
+						[ ConfigKey as symbol ]: emptyConfig,
+						[ ItemSearchKey as symbol ]: new DevItemSearcher(),
+						[ LanguageCodesProviderKey as symbol ]: {},
+						[ WikiRouterKey as symbol ]: { goToTitle },
+						[ MessagesKey as symbol ]: new Messages( new DevMessagesRepository() ),
+					},
+				},
+			} );
+
+			const lemmaInput = wrapper.find( '.wbl-snl-lemma-input input' );
+			await lemmaInput.setValue( 'foo' );
+
+			const languageInput = wrapper.find( '.wbl-snl-language-lookup input' );
+			await languageInput.setValue( '=Q123' );
+			await wrapper.find( '.wbl-snl-language-lookup .wikit-OptionsMenu__item' ).trigger( 'click' );
+
+			const spellingVariantInput = wrapper.find( '.wbl-snl-spelling-variant-lookup input' );
+			expect( spellingVariantInput.exists() ).toBe( false );
+
+			const lexicalCategoryInput = wrapper.find( '.wbl-snl-lexical-category-lookup input' );
+			await lexicalCategoryInput.setValue( '=Q456' );
+			await wrapper.find( '.wbl-snl-lexical-category-lookup .wikit-OptionsMenu__item' ).trigger( 'click' );
+
+			await wrapper.trigger( 'submit' );
+
+			const submitButton = wrapper.find( '.wikit-Button' );
+			expect( submitButton.attributes( 'disabled' ) ).toBe( '' );
+			expect( submitButton.text() ).toBe( 'Creating Lexeme...' );
+
+			reject( [ { type: 'test', message: 'error' } ] );
+			await wrapper.vm.$nextTick();
+			await wrapper.vm.$nextTick();
+			await wrapper.vm.$nextTick();
+			await wrapper.vm.$nextTick();
+			await wrapper.vm.$nextTick();
+			await wrapper.vm.$nextTick();
+
+			expect( submitButton.attributes( 'disabled' ) ).toBe( undefined );
+			expect( submitButton.text() ).toBe( 'Create Lexeme' );
+			expect( goToTitle ).not.toHaveBeenCalled();
+		} );
+
 	} );
 
 } );


### PR DESCRIPTION
Change the button’s label, and disable it, while the Lexeme is being created. When it’s done, reenable the button and change the label back.

Note that the button may still appear to be enabled when it’s clicked with the mouse (instead of another way to submit the form, like pressing Enter in the lemma input); this requires wmde/wikit#584 to fix.

In the tests, after rejecting the lexemeCreator promise, we apparently need to wait for the next Vue tick six times. I don’t know why, but five isn’t enough. I’m sorry.

Bug: T304511