### PR TITLE
Remove unused error prop from LemmaInput

### DIFF
--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -5,30 +5,14 @@ import { useConfig } from '@/plugins/ConfigPlugin/Config';
 
 interface Props {
 	modelValue: string;
-	error?: 'ERROR_LEMMA_TOO_LONG' | 'ERROR_NO_LEMMA' | null;
 }
 
-withDefaults( defineProps<Props>(), { error: null } );
+defineProps<Props>();
 
 defineEmits( [ 'update:modelValue' ] );
 
 const messages = useMessages();
 
-function buildError( errorKey: Props['error'] ) {
-	if ( errorKey === 'ERROR_LEMMA_TOO_LONG' ) {
-		return {
-			type: 'error',
-			message: messages.getUnescaped( 'wikibaselexeme-newlexeme-error-lemma-is-too-long' ),
-		};
-	}
-	if ( errorKey === 'ERROR_NO_LEMMA' ) {
-		return {
-			type: 'error',
-			message: messages.getUnescaped( 'wikibaselexeme-newlexeme-error-no-lemma' ),
-		};
-	}
-	return null;
-}
 const config = useConfig();
 const exampleLemma = config.placeholderExampleData.lemma;
 </script>
@@ -51,7 +35,6 @@ export default {
 		)"
 		name="lemma"
 		aria-required="true"
-		:error="buildError( error )"
 		:value="modelValue"
 		@input="$emit( 'update:modelValue', $event )"
 	/>

--- a/tests/unit/components/LemmaInput.test.ts
+++ b/tests/unit/components/LemmaInput.test.ts
@@ -30,18 +30,6 @@ describe( 'LemmaInput', () => {
 
 			expect( findInput( lemmaInputWrapper ).element.value ).toBe( testValue );
 		} );
-
-		it( ':error - displays an error message for value ERROR_LEMMA_TOO_LONG', () => {
-			const lemmaInputWrapper = createComponent( { props: { error: 'ERROR_LEMMA_TOO_LONG' } } );
-
-			expect( lemmaInputWrapper.text() ).toContain( 'wikibaselexeme-newlexeme-error-lemma-is-too-long' );
-		} );
-
-		it( ':error - displays an error message for value ERROR_NO_LEMMA', () => {
-			const lemmaInputWrapper = createComponent( { props: { error: 'ERROR_NO_LEMMA' } } );
-
-			expect( lemmaInputWrapper.text() ).toContain( 'wikibaselexeme-newlexeme-error-no-lemma' );
-		} );
 	} );
 
 	describe( '@events', () => {


### PR DESCRIPTION
It turns out that this prop in this form is not really suitable.

Follow-up commits will add a more consistent way to get these errors into this component.

This is the first of a series of PRs that split up  #192 