### PR TITLE
Use wikibase-entityselector-notfound for “no results”

### DIFF
--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -150,7 +150,7 @@ const messages = useMessages();
 		@input="onWikitOptionSelected"
 	>
 		<template #no-results>
-			{{ messages.getUnescaped( 'wikibaselexeme-newlexeme-no-results' ) }}
+			{{ messages.getUnescaped( 'wikibase-entityselector-notfound' ) }}
 		</template>
 	</wikit-lookup>
 </template>

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -107,7 +107,7 @@ export default {
 		@input="onOptionSelected"
 	>
 		<template #no-results>
-			{{ messages.getUnescaped( 'wikibaselexeme-newlexeme-no-results' ) }}
+			{{ messages.getUnescaped( 'wikibase-entityselector-notfound' ) }}
 		</template>
 	</wikit-lookup>
 </template>

--- a/src/plugins/MessagesPlugin/DevMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/DevMessagesRepository.ts
@@ -20,8 +20,8 @@ const messages: Record<MessageKeys, string> = {
 	'wikibaselexeme-newlexeme-submitting': 'Creating Lexeme...',
 	'wikibaselexeme-newlexeme-error-lemma-is-too-long': 'FIXME (copy is missing!)',
 	'wikibaselexeme-newlexeme-invalid-language-code-warning': 'This Item has an unrecognized language code. Please select one below.',
-	'wikibaselexeme-newlexeme-no-results': 'FIXME (copy is missing!)',
 	'wikibase-lexeme-lemma-language-option': '$1 ($2)',
+	'wikibase-entityselector-notfound': 'No match was found',
 	'wikibase-shortcopyrightwarning': 'By clicking "$1", you agree to the <a href="./$2">terms of use</a>, and you irrevocably agree to release your contribution under the <a href="$3">$4</a>.',
 	copyrightpage: 'Project:Copyrights',
 };

--- a/src/plugins/MessagesPlugin/MessageKeys.ts
+++ b/src/plugins/MessagesPlugin/MessageKeys.ts
@@ -17,8 +17,8 @@ type MessageKeys
  | 'wikibaselexeme-newlexeme-submitting'
  | 'wikibaselexeme-newlexeme-error-lemma-is-too-long'
  | 'wikibaselexeme-newlexeme-invalid-language-code-warning'
- | 'wikibaselexeme-newlexeme-no-results'
  | 'wikibase-lexeme-lemma-language-option'
+ | 'wikibase-entityselector-notfound'
  | 'wikibase-shortcopyrightwarning'
  | 'copyrightpage';
 


### PR DESCRIPTION
We can use this existing Wikibase message for the “no results” copy of the item lookup and spelling variant input, just like we’re already using `wikibase-shortcopyrightwarning` elsewhere.

Bug: T304340

----

I’m not sure if I like using this message for the spelling variant lookup as well… the English version seems fine, but it’s possible that some translations of the message are actually phrased in a way that is more specific to an entity selector, and doesn’t work as well for a spelling variant input.