### PR TITLE
Don’t reset spelling variant when language stays the same

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -144,10 +144,15 @@ export default function createActions(
 			}
 		},
 		async [ HANDLE_LANGUAGE_CHANGE ](
-			{ commit, dispatch }: RootContext,
+			{ state, commit, dispatch }: RootContext,
 			newLanguageItem: SearchedItemOption | null,
 		): Promise<void> {
+			const oldLanguageItem = state.language;
 			commit( SET_LANGUAGE, newLanguageItem );
+			if ( oldLanguageItem?.id === newLanguageItem?.id ) {
+				return;
+			}
+
 			commit( SET_LANGUAGE_CODE_FROM_LANGUAGE_ITEM, undefined );
 			commit( SET_SPELLING_VARIANT, '' );
 

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -395,6 +395,35 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 		expect( store.state.languageCodeFromLanguageItem ).toBe( retrievedLangCodeResult );
 		expect( isValidMock ).not.toHaveBeenCalled();
 	} );
+
+	it( 'does nothing when language does not change', async () => {
+		const actions = createActions(
+			unusedLexemeCreator,
+			unusedLangCodeRetriever,
+			unusedLanguageCodesProvider,
+			unusedTracker,
+		);
+
+		const store = createStore( {
+			state(): RootState {
+				return {
+					lemma: 'foo',
+					language: { id: 'Q123', display: {} },
+					lexicalCategory: { id: 'Q234', display: {} },
+					spellingVariant: 'bar',
+					languageCodeFromLanguageItem: null,
+				} as RootState;
+			},
+			actions,
+			mutations,
+		} );
+
+		await store.dispatch( HANDLE_LANGUAGE_CHANGE, { id: 'Q123' } );
+
+		expect( store.state.language ).toStrictEqual( { id: 'Q123' } );
+		expect( store.state.spellingVariant ).toBe( 'bar' );
+		expect( store.state.languageCodeFromLanguageItem ).toBe( null );
+	} );
 } );
 
 describe( HANDLE_INIT_PARAMS, () => {


### PR DESCRIPTION
When the user tabs through the form, leaving an item lookup will emit a “value” update for that lookup, even if the value didn’t change. That’s fine for the lexical category lookup, but problematic for the language lookup, because it would wipe whatever spelling variant the user had already entered, and also retry looking up the language code of the item. Instead, only have the `HANDLE_LANGUAGE_CHANGE` action reset the relevant state if the language actually changed, not if it stayed the same. (Note that we still commit the `SET_LANGUAGE` mutation, as the display section of the item may have changed.)

Bug: T201587