### PR TITLE
Reduce redundancy in integration test

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -17,7 +17,7 @@ import createActions from './actions';
 import mutations from './mutations';
 import RootState from './RootState';
 
-interface StoreServices {
+export interface StoreServices {
 	lexemeCreator: LexemeCreator;
 	langCodeRetriever: LangCodeRetriever;
 	languageCodesProvider: LanguageCodesProvider;


### PR DESCRIPTION
Most tests need only some minor adjustments to the overall form setup.
That setup is much more obvious if it is the only thing handed to the
createForm function, overriding specific defaults instead of repeating
them.