### PR TITLE
Configure lemma length for dev entry point

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
 						lemma: 'speak',
 						spellingVariant: 'en',
 					},
+					maxLemmaLength: 100,
 				};
 				const services = {
 					itemSearcher: new DevItemSearcher(),

--- a/src/plugins/MessagesPlugin/DevMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/DevMessagesRepository.ts
@@ -18,7 +18,7 @@ const messages: Record<MessageKeys, string> = {
 	'wikibaselexeme-newlexeme-submit': 'Create Lexeme',
 	'wikibaselexeme-newlexeme-submit-error': 'The server encountered a temporary error and could not complete your request. Please try again.',
 	'wikibaselexeme-newlexeme-submitting': 'Creating Lexeme...',
-	'wikibaselexeme-newlexeme-lemma-too-long-error': 'FIXME (copy is missing!)',
+	'wikibaselexeme-newlexeme-lemma-too-long-error': 'The Lemma field is too long; please make an entry no longer than $1 characters.',
 	'wikibaselexeme-newlexeme-invalid-language-code-warning': 'This Item has an unrecognized language code. Please select one below.',
 	'wikibase-lexeme-lemma-language-option': '$1 ($2)',
 	'wikibase-entityselector-notfound': 'No match was found',


### PR DESCRIPTION
Add a proper message to DevMessagesRepository now that we have the real copy, and hard-code a max length in index.html (100 instead of 1000, so it’s faster to hit by keyboard mashing).

Bug: T308654