### PR TITLE
export ItemLookup searchInput to be reachable from field components

### DIFF
--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -9,11 +9,12 @@ import { useConfig } from '@/plugins/ConfigPlugin/Config';
 
 interface Props {
 	modelValue: SearchedItemOption | null;
+	searchInput: string;
 }
 
 defineProps<Props>();
 
-defineEmits( [ 'update:modelValue' ] );
+defineEmits( [ 'update:modelValue', 'update:searchInput' ] );
 
 const messages = useMessages();
 
@@ -59,9 +60,11 @@ export default {
 				config.placeholderExampleData.languageLabel
 			)"
 			:value="modelValue"
+			:search-input="searchInput"
 			:search-for-items="searchForItems"
 			:error="error"
 			@update:model-value="$emit( 'update:modelValue', $event )"
+			@update:search-input="$emit( 'update:searchInput', $event )"
 		/>
 	</div>
 </template>

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -9,11 +9,12 @@ import { computed } from 'vue';
 
 interface Props {
 	modelValue: SearchedItemOption | null;
+	searchInput: string;
 }
 
 defineProps<Props>();
 
-defineEmits( [ 'update:modelValue' ] );
+defineEmits( [ 'update:modelValue', 'update:searchInput' ] );
 
 const messages = useMessages();
 const searcher = useItemSearch();
@@ -52,10 +53,12 @@ export default {
 				exampleLexCategory
 			)"
 			:value="modelValue"
+			:search-input="searchInput"
 			:search-for-items="searchForItems"
 			:item-suggestions="lexicalCategorySuggestions"
 			:error="error"
 			@update:model-value="$emit( 'update:modelValue', $event )"
+			@update:search-input="$emit( 'update:searchInput', $event )"
 		/>
 	</div>
 </template>

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -16,8 +16,10 @@ import LexicalCategoryInput from '@/components/LexicalCategoryInput.vue';
 import ErrorMessage from '@/components/ErrorMessage.vue';
 import {
 	CLEAR_PER_FIELD_ERRORS,
+	SET_LANGUAGE_SEARCH_INPUT,
 	SET_LEMMA,
 	SET_LEXICAL_CATEGORY,
+	SET_LEXICAL_CATEGORY_SEARCH_INPUT,
 	SET_SPELLING_VARIANT,
 } from '@/store/mutations';
 import { useWikiRouter } from '@/plugins/WikiRouterPlugin/WikiRouter';
@@ -47,6 +49,14 @@ const language = computed( {
 		}
 	},
 } );
+const languageSearchInput = computed( {
+	get(): string {
+		return store.state.languageSearchInput;
+	},
+	set( newLanguageSearchInput: string ): void {
+		store.commit( SET_LANGUAGE_SEARCH_INPUT, newLanguageSearchInput );
+	},
+} );
 const lexicalCategory = computed( {
 	get(): SearchedItemOption | null {
 		return store.state.lexicalCategory;
@@ -56,6 +66,14 @@ const lexicalCategory = computed( {
 		if ( newLexicalCategory ) {
 			store.commit( CLEAR_PER_FIELD_ERRORS, 'lexicalCategoryErrors' );
 		}
+	},
+} );
+const lexicalCategorySearchInput = computed( {
+	get(): string {
+		return store.state.lexicalCategorySearchInput;
+	},
+	set( newLexicalCategorySearchInput: string ): void {
+		store.commit( SET_LEXICAL_CATEGORY_SEARCH_INPUT, newLexicalCategorySearchInput );
 	},
 } );
 const showSpellingVariantInput = computed( () => {
@@ -131,6 +149,7 @@ export default {
 		/>
 		<language-input
 			v-model="language"
+			v-model:search-input="languageSearchInput"
 		/>
 		<spelling-variant-input
 			v-if="showSpellingVariantInput"
@@ -138,6 +157,7 @@ export default {
 		/>
 		<lexical-category-input
 			v-model="lexicalCategory"
+			v-model:search-input="lexicalCategorySearchInput"
 		/>
 		<!-- eslint-disable-next-line vue/no-v-html -->
 		<p class="wbl-snl-copyright" v-html="copyrightText" />

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -13,8 +13,10 @@ interface PerFieldError {
 export default interface RootState {
 	lemma: string;
 	language: SearchedItemOption | null;
+	languageSearchInput: string;
 	languageCodeFromLanguageItem: string | undefined | null | false;
 	lexicalCategory: SearchedItemOption | null;
+	lexicalCategorySearchInput: string;
 	spellingVariant: string;
 	globalErrors: SubmitError[];
 	perFieldErrors: {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -26,8 +26,10 @@ import {
 	CLEAR_ERRORS,
 	SET_LANGUAGE,
 	SET_LANGUAGE_CODE_FROM_LANGUAGE_ITEM,
+	SET_LANGUAGE_SEARCH_INPUT,
 	SET_LEMMA,
 	SET_LEXICAL_CATEGORY,
+	SET_LEXICAL_CATEGORY_SEARCH_INPUT,
 	SET_SPELLING_VARIANT,
 } from './mutations';
 import RootState from './RootState';
@@ -181,9 +183,17 @@ export default function createActions(
 					// don’t copy params.language.languageCode here
 				} );
 				await dispatch( HANDLE_ITEM_LANGUAGE_CODE, params.language.languageCode );
+				commit(
+					SET_LANGUAGE_SEARCH_INPUT,
+					params.language.display.label?.value ?? params.language.id,
+				);
 			}
 			if ( params.lexicalCategory !== undefined ) {
 				commit( SET_LEXICAL_CATEGORY, params.lexicalCategory );
+				commit(
+					SET_LEXICAL_CATEGORY_SEARCH_INPUT,
+					params.lexicalCategory.display.label?.value ?? params.lexicalCategory.id,
+				);
 			}
 		},
 		async [ HANDLE_ITEM_LANGUAGE_CODE ](

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -32,8 +32,10 @@ export default function initStore( {
 			return {
 				lemma: '',
 				language: null,
+				languageSearchInput: '',
 				languageCodeFromLanguageItem: undefined,
 				lexicalCategory: null,
+				lexicalCategorySearchInput: '',
 				spellingVariant: '',
 				globalErrors: [],
 				perFieldErrors: {

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -12,7 +12,9 @@ import RootState, { SubmitError } from './RootState';
 
 export const SET_LEMMA = 'setLemma';
 export const SET_LANGUAGE = 'setLanguage';
+export const SET_LANGUAGE_SEARCH_INPUT = 'setLanguageSearchInput';
 export const SET_LEXICAL_CATEGORY = 'setLexicalCategory';
+export const SET_LEXICAL_CATEGORY_SEARCH_INPUT = 'setLexicalCategorySearchInput';
 export const SET_SPELLING_VARIANT = 'setSpellingVariant';
 export const SET_LANGUAGE_CODE_FROM_LANGUAGE_ITEM = 'setLanguageCodeFromLanguageItem';
 export const ADD_ERRORS = 'addErrors';
@@ -27,8 +29,16 @@ export default {
 	[ SET_LANGUAGE ]( state: RootState, language: SearchedItemOption | null ): void {
 		state.language = language;
 	},
+	[ SET_LANGUAGE_SEARCH_INPUT ](
+		state: RootState, languageSearchInput: string ): void {
+		state.languageSearchInput = languageSearchInput;
+	},
 	[ SET_LEXICAL_CATEGORY ]( state: RootState, lexicalCategory: SearchedItemOption | null ): void {
 		state.lexicalCategory = lexicalCategory;
+	},
+	[ SET_LEXICAL_CATEGORY_SEARCH_INPUT ](
+		state: RootState, lexicalCategorySearchInput: string ): void {
+		state.lexicalCategorySearchInput = lexicalCategorySearchInput;
 	},
 	[ SET_SPELLING_VARIANT ]( state: RootState, spellingVariant: string ): void {
 		state.spellingVariant = spellingVariant;

--- a/tests/unit/components/ItemLookup.test.ts
+++ b/tests/unit/components/ItemLookup.test.ts
@@ -22,6 +22,7 @@ function createLookup( propsOverrides: any = {} ): VueWrapper<any> {
 
 async function setSearchInput( lookup: VueWrapper, searchInput: string ): Promise<void> {
 	await lookup.find( 'input' ).setValue( searchInput );
+	await lookup.setProps( { searchInput } );
 }
 
 const exampleSearchResults = [
@@ -117,21 +118,6 @@ describe( 'ItemLookup', () => {
 
 			expect( lookup.findComponent( WikitLookup ).props().value.label )
 				.toBe( exampleSearchResults[ selectedItemId ].display.label?.value );
-		} );
-
-		it( ':value - sets the search input', async () => {
-			const lookup = createLookup( { value: {
-				id: 'Q1',
-				display: {
-					label: { language: 'en', value: 'some label' },
-				},
-			} } );
-			expect( lookup.findComponent( WikitLookup ).props().searchInput )
-				.toBe( 'some label' );
-
-			await lookup.setProps( { value: { id: 'Q2', display: {} } } );
-			expect( lookup.findComponent( WikitLookup ).props().searchInput )
-				.toBe( 'Q2' );
 		} );
 
 		it( ':value - provides a menu item', async () => {

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -432,7 +432,9 @@ describe( HANDLE_INIT_PARAMS, () => {
 		const state = (): RootState => ( {
 			lemma: 'lemma',
 			language: { id: 'Q123', display: {} },
+			languageSearchInput: '',
 			lexicalCategory: { id: 'Q234', display: {} },
+			lexicalCategorySearchInput: '',
 			spellingVariant: 'bar',
 			languageCodeFromLanguageItem: false,
 			globalErrors: [],
@@ -474,7 +476,9 @@ describe( HANDLE_INIT_PARAMS, () => {
 				return {
 					lemma: '',
 					language: null,
+					languageSearchInput: '',
 					lexicalCategory: null,
+					lexicalCategorySearchInput: '',
 					spellingVariant: '',
 					languageCodeFromLanguageItem: undefined,
 					globalErrors: [],
@@ -512,7 +516,9 @@ describe( HANDLE_INIT_PARAMS, () => {
 		expect( store.state ).toStrictEqual( {
 			lemma: 'lemma',
 			language,
+			languageSearchInput: language.display.label.value,
 			lexicalCategory,
+			lexicalCategorySearchInput: lexicalCategory.display.label.value,
 			spellingVariant: 'en-gb',
 			languageCodeFromLanguageItem: 'en',
 			globalErrors: [],
@@ -541,7 +547,9 @@ describe( HANDLE_INIT_PARAMS, () => {
 				return {
 					lemma: '',
 					language: null,
+					languageSearchInput: '',
 					lexicalCategory: null,
+					lexicalCategorySearchInput: '',
 					spellingVariant: '',
 					languageCodeFromLanguageItem: undefined,
 					globalErrors: [],


### PR DESCRIPTION
Currently implemented only for Lexeme language and lexical category
(spelling variant implementation still pending).
for each field, add a searchInput store value, using which the
component receives the correct error message in the case input
is empty/invalid.

Bug: T310134