### PR TITLE
Remove emits validators

### DIFF
--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -23,11 +23,7 @@ const props = withDefaults( defineProps<Props>(), {
 	itemSuggestions: () => [],
 } );
 
-const emit = defineEmits( {
-	'update:modelValue': ( value: Props['value'] ) => {
-		return value === null || /^Q\d+$/.test( value.id );
-	},
-} );
+const emit = defineEmits( [ 'update:modelValue' ] );
 
 const searchInput = ref( '' );
 watchEffect( () => {

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -35,11 +35,7 @@ languageCodesProvider.getLanguages().forEach(
 
 const menuItems = ref( [] as WikitMenuItem[] );
 
-const emit = defineEmits( {
-	'update:modelValue': ( selectedLang: string | null ) => {
-		return selectedLang;
-	},
-} );
+const emit = defineEmits( [ 'update:modelValue' ] );
 
 const searchInput = ref( '' );
 const onSearchInput = ( inputValue: string ) => {


### PR DESCRIPTION
These seem like useless complication to me. The `SpellingVariantInput` validator was even incorrect, I would argue – it would reject `null` as an invalid value, when in fact that’s the correct value when the user hasn’t selected anything or cleared the input.

----

Noticed while working on https://github.com/wmde/new-lexeme-special-page/pull/223.