### PR TITLE
Distinguish between message type for lookup fields

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -16,6 +16,7 @@ import LangCodeRetriever from '@/data-access/LangCodeRetriever';
 import LanguageCodesProvider from '@/data-access/LanguageCodesProvider';
 import LexemeCreator from '@/data-access/LexemeCreator';
 import Tracker from '@/data-access/tracking/Tracker';
+import MessageKeys from '@/plugins/MessagesPlugin/MessageKeys';
 import {
 	ActionContext,
 	ActionTree,

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -81,17 +81,29 @@ export default function createActions(
 				formData.validLemma = state.lemma;
 			}
 			if ( !state.language ) {
+				let messageKey: MessageKeys;
+				if ( state.languageSearchInput ) {
+					messageKey = 'wikibaselexeme-newlexeme-language-invalid-error';
+				} else {
+					messageKey = 'wikibaselexeme-newlexeme-language-empty-error';
+				}
 				commit(
 					ADD_PER_FIELD_ERROR,
-					{ field: 'languageErrors', error: { messageKey: 'wikibaselexeme-newlexeme-language-empty-error' } },
+					{ field: 'languageErrors', error: { messageKey: messageKey } },
 				);
 			} else {
 				formData.validLanguageId = state.language.id;
 			}
 			if ( !state.lexicalCategory ) {
+				let messageKey: MessageKeys;
+				if ( state.lexicalCategorySearchInput ) {
+					messageKey = 'wikibaselexeme-newlexeme-lexicalcategory-invalid-error';
+				} else {
+					messageKey = 'wikibaselexeme-newlexeme-lexicalcategory-empty-error';
+				}
 				commit(
 					ADD_PER_FIELD_ERROR,
-					{ field: 'lexicalCategoryErrors', error: { messageKey: 'wikibaselexeme-newlexeme-lexicalcategory-empty-error' } },
+					{ field: 'lexicalCategoryErrors', error: { messageKey: messageKey } },
 				);
 			} else {
 				formData.validLexicalCategoryId = state.lexicalCategory.id;

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -196,7 +196,9 @@ describe( CREATE_LEXEME, () => {
 				return {
 					lemma: 'example lemma',
 					language: null,
+					languageSearchInput: '',
 					lexicalCategory: null,
+					lexicalCategorySearchInput: '',
 					spellingVariant: 'en',
 				} as RootState;
 			},

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -231,9 +231,9 @@ describe( CREATE_LEXEME, () => {
 				return {
 					lemma: 'example lemma',
 					language: null,
-					languageSearchInput: { },
+					languageSearchInput: 'invalid input',
 					lexicalCategory: null,
-					lexicalCategorySearchInput: { },
+					lexicalCategorySearchInput: 'invalid input',
 					spellingVariant: 'en',
 				} as RootState;
 			},

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -216,6 +216,43 @@ describe( CREATE_LEXEME, () => {
 			field: 'lexicalCategoryErrors',
 		} );
 	} );
+	it( 'shows a per-field error for invalid lexical category and language and rejects', async () => {
+		const actions = createActions(
+			unusedLexemeCreator,
+			unusedLangCodeRetriever,
+			unusedLanguageCodesProvider,
+			unusedTracker,
+		);
+		const mockMutations = {
+			[ ADD_PER_FIELD_ERROR ]: jest.fn(),
+		};
+		const store = createStore( {
+			state(): RootState {
+				return {
+					lemma: 'example lemma',
+					language: null,
+					languageSearchInput: { },
+					lexicalCategory: null,
+					lexicalCategorySearchInput: { },
+					spellingVariant: 'en',
+				} as RootState;
+			},
+			actions,
+			mutations: mockMutations,
+		} );
+
+		await expect( store.dispatch( CREATE_LEXEME ) ).rejects.toStrictEqual( new Error( 'Not all fields are valid' ) );
+
+		expect( mockMutations[ ADD_PER_FIELD_ERROR ] ).toHaveBeenCalledTimes( 2 );
+		expect( mockMutations[ ADD_PER_FIELD_ERROR ].mock.calls[ 0 ][ 1 ] ).toStrictEqual( {
+			error: { messageKey: 'wikibaselexeme-newlexeme-language-invalid-error' },
+			field: 'languageErrors',
+		} );
+		expect( mockMutations[ ADD_PER_FIELD_ERROR ].mock.calls[ 1 ][ 1 ] ).toStrictEqual( {
+			error: { messageKey: 'wikibaselexeme-newlexeme-lexicalcategory-invalid-error' },
+			field: 'lexicalCategoryErrors',
+		} );
+	} );
 
 } );
 


### PR DESCRIPTION
for each lookup field, ascertain which type of message key
is required (field empty/entry invalid) and use that while committing
This is a chunk broken down from [PR #223](https://github.com/wmde/new-lexeme-special-page/pull/223)

Bug: T310134