### PR TITLE
Define emitted events using type syntax

### DIFF
--- a/src/components/.eslintrc.js
+++ b/src/components/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+	rules: {
+		// does not support TypeScript syntax properly
+		// (spaces in <> should be allowed)
+		'func-call-spacing': 'off',
+		// defineEmits<{}>() should use an object type with call signatures,
+		// even if there is only one event and a function type would be possible
+		'@typescript-eslint/prefer-function-type': 'off',
+	},
+};

--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -13,7 +13,9 @@ interface Props {
 
 defineProps<Props>();
 
-defineEmits( [ 'update:modelValue' ] );
+defineEmits<{
+	( e: 'update:modelValue', modelValue: Props['modelValue'] ): void;
+}>();
 
 const messages = useMessages();
 

--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -11,7 +11,9 @@ interface Props {
 
 const props = defineProps<Props>();
 
-defineEmits( [ 'update:modelValue' ] );
+defineEmits<{
+	( e: 'update:modelValue', modelValue: Props['modelValue'] ): void;
+}>();
 
 const messages = useMessages();
 

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -13,7 +13,9 @@ interface Props {
 
 defineProps<Props>();
 
-defineEmits( [ 'update:modelValue' ] );
+defineEmits<{
+	( e: 'update:modelValue', modelValue: Props['modelValue'] ): void;
+}>();
 
 const messages = useMessages();
 const searcher = useItemSearch();

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -36,7 +36,7 @@ languageCodesProvider.getLanguages().forEach(
 const menuItems = ref( [] as WikitMenuItem[] );
 
 const emit = defineEmits( {
-	'update:modelValue': ( selectedLang: string | null ) => {
+	'update:modelValue': ( selectedLang: Props['modelValue'] ) => {
 		return selectedLang === null || selectedLang.length > 0;
 	},
 } );


### PR DESCRIPTION
When no validator function is needed, [this syntax][1] can be used to specify types for the emitted events. This provides additional clarity and type safety over the array syntax.

Two eslint rules that don’t work well with this have to be disabled:

> Unexpected whitespace between function name and paren
> Type literal only has a call signature, you should use a function type instead

[1]: https://vuejs.org/guide/typescript/composition-api.html#typing-component-emits