### PR TITLE
Make SpellingVariantInput searchInput a prop

### DIFF
--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -19,6 +19,7 @@ import {
 	SET_LEMMA,
 	SET_LEXICAL_CATEGORY,
 	SET_SPELLING_VARIANT,
+	SET_SPELLING_VARIANT_SEARCH_INPUT,
 } from '@/store/mutations';
 import { useWikiRouter } from '@/plugins/WikiRouterPlugin/WikiRouter';
 
@@ -71,6 +72,14 @@ const spellingVariant = computed( {
 		if ( newSpellingVariant ) {
 			store.commit( CLEAR_PER_FIELD_ERRORS, 'spellingVariantErrors' );
 		}
+	},
+} );
+const spellingVariantSearchInput = computed( {
+	get(): string {
+		return store.state.spellingVariantSearchInput;
+	},
+	set( newSpellingVariantSearchInput: string ): void {
+		store.commit( SET_SPELLING_VARIANT_SEARCH_INPUT, newSpellingVariantSearchInput );
 	},
 } );
 
@@ -135,6 +144,7 @@ export default {
 		<spelling-variant-input
 			v-if="showSpellingVariantInput"
 			v-model="spellingVariant"
+			v-model:search-input="spellingVariantSearchInput"
 		/>
 		<lexical-category-input
 			v-model="lexicalCategory"

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -9,6 +9,7 @@ import { useStore } from 'vuex';
 
 interface Props {
 	modelValue: string | null;
+	searchInput: string;
 }
 
 interface WikitMenuItem {
@@ -17,7 +18,9 @@ interface WikitMenuItem {
 	value: string;
 }
 
-const props = defineProps<Props>();
+const props = withDefaults( defineProps<Props>(), {
+	searchInput: '',
+} );
 
 const languageCodesProvider = useLanguageCodesProvider();
 const messages = useMessages();
@@ -39,11 +42,11 @@ const emit = defineEmits( {
 	'update:modelValue': ( selectedLang: Props['modelValue'] ) => {
 		return selectedLang === null || selectedLang.length > 0;
 	},
+	'update:searchInput': null,
 } );
 
-const searchInput = ref( '' );
 const onSearchInput = ( inputValue: string ) => {
-	searchInput.value = inputValue;
+	emit( 'update:searchInput', inputValue );
 	if ( inputValue.trim() === '' ) {
 		menuItems.value = [];
 		return;

--- a/src/store/RootState.ts
+++ b/src/store/RootState.ts
@@ -16,6 +16,7 @@ export default interface RootState {
 	languageCodeFromLanguageItem: string | undefined | null | false;
 	lexicalCategory: SearchedItemOption | null;
 	spellingVariant: string;
+	spellingVariantSearchInput: string;
 	globalErrors: SubmitError[];
 	perFieldErrors: {
 		lemmaErrors: PerFieldError[];

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -29,6 +29,7 @@ import {
 	SET_LEMMA,
 	SET_LEXICAL_CATEGORY,
 	SET_SPELLING_VARIANT,
+	SET_SPELLING_VARIANT_SEARCH_INPUT,
 } from './mutations';
 import RootState from './RootState';
 
@@ -173,6 +174,7 @@ export default function createActions(
 			}
 			if ( params.spellVarCode !== undefined ) {
 				commit( SET_SPELLING_VARIANT, params.spellVarCode );
+				commit( SET_SPELLING_VARIANT_SEARCH_INPUT, params.spellVarCode );
 			}
 			if ( params.language !== undefined ) {
 				commit( SET_LANGUAGE, {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -35,6 +35,7 @@ export default function initStore( {
 				languageCodeFromLanguageItem: undefined,
 				lexicalCategory: null,
 				spellingVariant: '',
+				spellingVariantSearchInput: '',
 				globalErrors: [],
 				perFieldErrors: {
 					lemmaErrors: [],

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -14,6 +14,7 @@ export const SET_LEMMA = 'setLemma';
 export const SET_LANGUAGE = 'setLanguage';
 export const SET_LEXICAL_CATEGORY = 'setLexicalCategory';
 export const SET_SPELLING_VARIANT = 'setSpellingVariant';
+export const SET_SPELLING_VARIANT_SEARCH_INPUT = 'setSpellingVariantSearchInput';
 export const SET_LANGUAGE_CODE_FROM_LANGUAGE_ITEM = 'setLanguageCodeFromLanguageItem';
 export const ADD_ERRORS = 'addErrors';
 export const ADD_PER_FIELD_ERROR = 'addPerFieldError';
@@ -32,6 +33,10 @@ export default {
 	},
 	[ SET_SPELLING_VARIANT ]( state: RootState, spellingVariant: string ): void {
 		state.spellingVariant = spellingVariant;
+	},
+	[ SET_SPELLING_VARIANT_SEARCH_INPUT ](
+		state: RootState, spellingVariantSearchInput: string ): void {
+		state.spellingVariantSearchInput = spellingVariantSearchInput;
 	},
 	[ SET_LANGUAGE_CODE_FROM_LANGUAGE_ITEM ](
 		state: RootState,

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -434,6 +434,7 @@ describe( HANDLE_INIT_PARAMS, () => {
 			language: { id: 'Q123', display: {} },
 			lexicalCategory: { id: 'Q234', display: {} },
 			spellingVariant: 'bar',
+			spellingVariantSearchInput: 'bar',
 			languageCodeFromLanguageItem: false,
 			globalErrors: [],
 			perFieldErrors: {
@@ -476,6 +477,7 @@ describe( HANDLE_INIT_PARAMS, () => {
 					language: null,
 					lexicalCategory: null,
 					spellingVariant: '',
+					spellingVariantSearchInput: '',
 					languageCodeFromLanguageItem: undefined,
 					globalErrors: [],
 					perFieldErrors: {
@@ -514,6 +516,7 @@ describe( HANDLE_INIT_PARAMS, () => {
 			language,
 			lexicalCategory,
 			spellingVariant: 'en-gb',
+			spellingVariantSearchInput: 'en-gb',
 			languageCodeFromLanguageItem: 'en',
 			globalErrors: [],
 			perFieldErrors: {
@@ -543,6 +546,7 @@ describe( HANDLE_INIT_PARAMS, () => {
 					language: null,
 					lexicalCategory: null,
 					spellingVariant: '',
+					spellingVariantSearchInput: '',
 					languageCodeFromLanguageItem: undefined,
 					globalErrors: [],
 					perFieldErrors: {


### PR DESCRIPTION
Similar to what #223 does for the ItemLookup searchInput, make the SpellingVariantInput searchInput a prop and wire it up with the store. This will let the store show a different error message when the input isn’t empty but hasn’t been selected (not implemented in this commit).

Also, make HANDLE_INIT_PARAMS set the search input when the spelling variant has been loaded from the URL. Previously, the search input was left empty in that case, making it appear as if the spelling variant hadn’t been loaded. With this change, the input is set to just the language code (rather than the language name and code, combined via an interface message) – this should be improved further, but I think that needs a bit more consideration.

Bug: T310134

---

You can test the HANDLE_INIT_PARAMS behavior with [these URL parameters](http://localhost:3000/?initParams={%22language%22%3A{%22id%22%3A%22Q1860%22%2C%22display%22%3A{%22label%22%3A{%22language%22%3A%22en%22%2C%22value%22%3A%22English%22}%2C%22description%22%3A{%22language%22%3A%22en%22%2C%22value%22%3A%22language%22}}%2C%22languageCode%22%3Anull},%22spellVarCode%22:%22en%22}) ([staging site](https://d3002abfe74c2432e92dcb465ca996082011--new-lexeme-special-page.netlify.app/?initParams={%22language%22%3A{%22id%22%3A%22Q1860%22%2C%22display%22%3A{%22label%22%3A{%22language%22%3A%22en%22%2C%22value%22%3A%22English%22}%2C%22description%22%3A{%22language%22%3A%22en%22%2C%22value%22%3A%22language%22}}%2C%22languageCode%22%3Anull},%22spellVarCode%22:%22en%22}), [this pull request](https://9a0d889257f2fa64e6e9c5b29ce710b66142--new-lexeme-special-page.netlify.app/?initParams={%22language%22%3A{%22id%22%3A%22Q1860%22%2C%22display%22%3A{%22label%22%3A{%22language%22%3A%22en%22%2C%22value%22%3A%22English%22}%2C%22description%22%3A{%22language%22%3A%22en%22%2C%22value%22%3A%22language%22}}%2C%22languageCode%22%3Anull},%22spellVarCode%22:%22en%22})).