### PR TITLE
Spelling Variant - distinguish between message types

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -115,9 +115,15 @@ export default function createActions(
 				} else if ( state.languageCodeFromLanguageItem ) {
 					formData.validSpellingVariant = state.languageCodeFromLanguageItem;
 				} else {
+					let messageKey: MessageKeys;
+					if ( state.spellingVariantSearchInput ) {
+						messageKey = 'wikibaselexeme-newlexeme-lemma-language-invalid-error';
+					} else {
+						messageKey = 'wikibaselexeme-newlexeme-lemma-language-empty-error';
+					}
 					commit(
 						ADD_PER_FIELD_ERROR,
-						{ field: 'spellingVariantErrors', error: { messageKey: 'wikibaselexeme-newlexeme-lemma-language-empty-error' } },
+						{ field: 'spellingVariantErrors', error: { messageKey: messageKey } },
 					);
 				}
 			}

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -253,6 +253,38 @@ describe( CREATE_LEXEME, () => {
 			field: 'lexicalCategoryErrors',
 		} );
 	} );
+	it( 'shows a per-field error for invalid spelling variant and rejects', async () => {
+		const actions = createActions(
+			unusedLexemeCreator,
+			unusedLangCodeRetriever,
+			unusedLanguageCodesProvider,
+			unusedTracker,
+		);
+		const mockMutations = {
+			[ ADD_PER_FIELD_ERROR ]: jest.fn(),
+		};
+		const store = createStore( {
+			state(): RootState {
+				return {
+					lemma: 'example lemma',
+					language: { id: 'Q123', display: {} },
+					lexicalCategory: { id: 'Q234', display: {} },
+					spellingVariant: '',
+					spellingVariantSearchInput: 'invalid input',
+				} as RootState;
+			},
+			actions,
+			mutations: mockMutations,
+		} );
+
+		await expect( store.dispatch( CREATE_LEXEME ) ).rejects.toStrictEqual( new Error( 'Not all fields are valid' ) );
+
+		expect( mockMutations[ ADD_PER_FIELD_ERROR ] ).toHaveBeenCalledTimes( 1 );
+		expect( mockMutations[ ADD_PER_FIELD_ERROR ].mock.calls[ 0 ][ 1 ] ).toStrictEqual( {
+			error: { messageKey: 'wikibaselexeme-newlexeme-lemma-language-invalid-error' },
+			field: 'spellingVariantErrors',
+		} );
+	} );
 
 } );
 


### PR DESCRIPTION
This adds the same behaviour as [PR #229](https://github.com/wmde/new-lexeme-special-page/pull/229)
does for language and lexical category - displays
a different message depending on whether the searchInput
is empty or not.

Bug: T310134