### PR TITLE
Use backward compatible CSS with literal directions

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,7 +4,7 @@
 		"stylelint-config-standard-scss",
 		"stylelint-config-recommended-vue/scss"
 	],
-	"plugins": ["stylelint-use-logical-spec", "@namics/stylelint-bem"],
+	"plugins": ["@namics/stylelint-bem"],
 	"rules": {
 		"plugin/stylelint-bem-namics": {
 			"patternPrefixes": [],
@@ -12,7 +12,6 @@
 			"namespaces": ["wbl-snl-"]
 		},
 		"indentation": "tab",
-		"selector-max-id": 1,
-		"liberty/use-logical-spec": true
+		"selector-max-id": 1
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
 				"stylelint-config-recommended-vue": "^1.1.0",
 				"stylelint-config-standard-scss": "^4.0.0",
 				"stylelint-config-wikimedia": "^0.13.0",
-				"stylelint-use-logical-spec": "^4.0.0",
 				"ts-jest": "^27.1.3",
 				"typescript": "^4.5.5",
 				"vite": "^2.7.13",
@@ -11970,18 +11969,6 @@
 				"stylelint": "^14.5.1"
 			}
 		},
-		"node_modules/stylelint-use-logical-spec": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-4.0.0.tgz",
-			"integrity": "sha512-/pHsmBQEoyTQj0rtG62q1ycn+Z4jAMWFlxVjxb7klnD+ImtKc8H5WMuaU6Y/Xp5VynblQE7nvozWXUALFBAWtQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.0.0"
-			},
-			"peerDependencies": {
-				"stylelint": ">=13"
-			}
-		},
 		"node_modules/stylelint/node_modules/balanced-match": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
@@ -21919,13 +21906,6 @@
 				"postcss-selector-parser": "^6.0.6",
 				"postcss-value-parser": "^4.1.0"
 			}
-		},
-		"stylelint-use-logical-spec": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-use-logical-spec/-/stylelint-use-logical-spec-4.0.0.tgz",
-			"integrity": "sha512-/pHsmBQEoyTQj0rtG62q1ycn+Z4jAMWFlxVjxb7klnD+ImtKc8H5WMuaU6Y/Xp5VynblQE7nvozWXUALFBAWtQ==",
-			"dev": true,
-			"requires": {}
 		},
 		"supports-color": {
 			"version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
 		"stylelint-config-recommended-vue": "^1.1.0",
 		"stylelint-config-standard-scss": "^4.0.0",
 		"stylelint-config-wikimedia": "^0.13.0",
-		"stylelint-use-logical-spec": "^4.0.0",
 		"ts-jest": "^27.1.3",
 		"typescript": "^4.5.5",
 		"vite": "^2.7.13",

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -195,7 +195,7 @@ export default {
 
 .wbl-snl-form {
 	& > * + * {
-		margin-block-start: $dimension-layout-xsmall;
+		margin-top: $dimension-layout-xsmall;
 	}
 
 	// Box model

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -128,7 +128,7 @@ export default {
 
 .wbl-snl-spelling-variant-lookup {
 	&__help-link {
-		padding-block-end: $wikit-Label-padding-block-end;
+		padding-bottom: $wikit-Label-padding-block-end;
 		display: inline-block;
 	}
 }


### PR DESCRIPTION
This PR is effectively an alternative to #236 

We would have to transform the logical directions in order to support all older browser that we want to support. However, that transformation would also apply to wikit, effectively duplicating itself.