### PR TITLE
Show warning for anonymous users

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
 
 				const config = {
 					rootSelector: '#app',
+					isAnonymous: false,
 					licenseUrl: 'https://creativecommons.org/publicdomain/zero/1.0/',
 					licenseName: 'Creative Commons CC0',
 					wikibaseLexemeTermLanguages: new Map([
@@ -117,6 +118,9 @@
 				const params = new URLSearchParams( location.search );
 				if ( params.has( 'initParams' ) ) {
 					config.initParams = JSON.parse( params.get( 'initParams' ) );
+				}
+				if ( params.has( 'isAnonymous' ) ) {
+					config.isAnonymous = params.get( 'isAnonymous' ) !== 'false';
 				}
 
 				createAndMount( config, services );

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
+import AnonymousEditWarning from '@/components/AnonymousEditWarning.vue';
 import NewLexemeForm from '@/components/NewLexemeForm.vue';
 import SearchExisting from '@/components/SearchExisting.vue';
 import '@wmde/wikit-vue-components/dist/wikit-vue-components.css';
+
 </script>
 
 <template>
 	<teleport to="#wbl-snl-intro-text-wrapper">
 		<search-existing />
+		<anonymous-edit-warning />
 	</teleport>
 	<div class="wbl-snl-app">
 		<new-lexeme-form />

--- a/src/components/AnonymousEditWarning.vue
+++ b/src/components/AnonymousEditWarning.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { useConfig } from '@/plugins/ConfigPlugin/Config';
+import { useMessages } from '@/plugins/MessagesPlugin/Messages';
+import { computed } from 'vue';
+
+const messages = useMessages();
+const warning = computed(
+	() => messages.get( 'wikibase-anonymouseditwarning' ) );
+const config = useConfig();
+
+</script>
+
+<template>
+	<!-- eslint-disable vue/no-v-html -->
+	<p
+		v-if="config.isAnonymous"
+		class="wbl-snl-anonymous-edit-warning"
+		v-html="warning"
+	/>
+	<!-- eslint-enable -->
+</template>
+
+<style lang="scss" scoped>
+@import "@wmde/wikit-tokens/variables";
+@import "@wmde/wikit-vue-components/src/styles/mixins/Typography";
+
+.wbl-snl-anonymous-edit-warning {
+	@include body;
+}
+</style>

--- a/src/components/AnonymousEditWarning.vue
+++ b/src/components/AnonymousEditWarning.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import WarningMessage from '@/components/WarningMessage.vue';
 import { useConfig } from '@/plugins/ConfigPlugin/Config';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import { computed } from 'vue';
@@ -11,20 +12,19 @@ const config = useConfig();
 </script>
 
 <template>
-	<!-- eslint-disable vue/no-v-html -->
-	<p
+	<warning-message
 		v-if="config.isAnonymous"
 		class="wbl-snl-anonymous-edit-warning"
-		v-html="warning"
-	/>
-	<!-- eslint-enable -->
+	>
+		<!-- eslint-disable-next-line vue/no-v-html -->
+		<span v-html="warning" />
+	</warning-message>
 </template>
 
 <style lang="scss" scoped>
 @import "@wmde/wikit-tokens/variables";
-@import "@wmde/wikit-vue-components/src/styles/mixins/Typography";
 
 .wbl-snl-anonymous-edit-warning {
-	@include body;
+	margin: $dimension-spacing-small 0;
 }
 </style>

--- a/src/components/WarningMessage.vue
+++ b/src/components/WarningMessage.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { Message as WikitMessage } from '@wmde/wikit-vue-components';
+</script>
+
+<template>
+	<wikit-message type="warning">
+		<slot />
+	</wikit-message>
+</template>

--- a/src/plugins/ConfigPlugin/Config.ts
+++ b/src/plugins/ConfigPlugin/Config.ts
@@ -5,6 +5,7 @@ import {
 } from 'vue';
 
 export interface Config {
+	readonly isAnonymous: boolean;
 	readonly licenseUrl: string;
 	readonly licenseName: string;
 	readonly wikibaseLexemeTermLanguages: Map<string, string>;

--- a/src/plugins/MessagesPlugin/DevMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/DevMessagesRepository.ts
@@ -25,6 +25,7 @@ const messages: Record<MessageKeys, string> = {
 	'wikibaselexeme-newlexeme-submitting': 'Creating Lexeme...',
 	'wikibaselexeme-newlexeme-lemma-too-long-error': 'The Lemma field is too long; please make an entry no longer than $1 characters.',
 	'wikibaselexeme-newlexeme-invalid-language-code-warning': 'This Item has an unrecognized language code. Please select one below.',
+	'wikibase-anonymouseditwarning': 'Warning: You are not logged in. Your IP address will be publicly visible ... If you <strong>log in</strong> or <strong>create an account</strong> ...',
 	'wikibase-lexeme-lemma-language-option': '$1 ($2)',
 	'wikibase-entityselector-notfound': 'No match was found',
 	'wikibase-shortcopyrightwarning': 'By clicking "$1", you agree to the <a href="./$2">terms of use</a>, and you irrevocably agree to release your contribution under the <a href="$3">$4</a>.',

--- a/src/plugins/MessagesPlugin/MessageKeys.ts
+++ b/src/plugins/MessagesPlugin/MessageKeys.ts
@@ -22,6 +22,7 @@ type MessageKeys
  | 'wikibaselexeme-newlexeme-submitting'
  | 'wikibaselexeme-newlexeme-lemma-too-long-error'
  | 'wikibaselexeme-newlexeme-invalid-language-code-warning'
+ | 'wikibase-anonymouseditwarning'
  | 'wikibase-lexeme-lemma-language-option'
  | 'wikibase-entityselector-notfound'
  | 'wikibase-shortcopyrightwarning'

--- a/tests/integration/App.test.ts
+++ b/tests/integration/App.test.ts
@@ -37,6 +37,7 @@ describe( 'App.vue', () => {
 			tracker: unusedTracker,
 		} );
 		const emptyConfig: Config = {
+			isAnonymous: false,
 			licenseUrl: '',
 			licenseName: '',
 			wikibaseLexemeTermLanguages: new Map(),

--- a/tests/integration/NewLexemeForm.test.ts
+++ b/tests/integration/NewLexemeForm.test.ts
@@ -21,6 +21,7 @@ describe( 'NewLexemeForm', () => {
 	let store: ReturnType<typeof initStore>;
 
 	const emptyConfig: Config = {
+		isAnonymous: false,
 		licenseUrl: '',
 		licenseName: '',
 		wikibaseLexemeTermLanguages: new Map(),

--- a/tests/unit/components/AnonymousEditWarning.test.ts
+++ b/tests/unit/components/AnonymousEditWarning.test.ts
@@ -16,7 +16,7 @@ describe( 'AnonymousEditWarning', () => {
 			},
 		} );
 
-		expect( warning.element.childElementCount ).toBe( 0 );
+		expect( warning.isVisible() ).toBe( false );
 		expect( messages.get ).not.toHaveBeenCalled();
 	} );
 

--- a/tests/unit/components/AnonymousEditWarning.test.ts
+++ b/tests/unit/components/AnonymousEditWarning.test.ts
@@ -1,0 +1,38 @@
+import AnonymousEditWarning from '@/components/AnonymousEditWarning.vue';
+import { ConfigKey } from '@/plugins/ConfigPlugin/Config';
+import { MessagesKey } from '@/plugins/MessagesPlugin/Messages';
+import { mount } from '@vue/test-utils';
+
+describe( 'AnonymousEditWarning', () => {
+
+	it( 'does nothing if not anonymous', () => {
+		const messages = { get: jest.fn() };
+		const warning = mount( AnonymousEditWarning, {
+			global: {
+				provide: {
+					[ ConfigKey as symbol ]: { isAnonymous: false },
+					[ MessagesKey as symbol ]: messages,
+				},
+			},
+		} );
+
+		expect( warning.element.childElementCount ).toBe( 0 );
+		expect( messages.get ).not.toHaveBeenCalled();
+	} );
+
+	it( 'matches snapshot if anonymous', () => {
+		const messages = { get: jest.fn().mockImplementation( ( key ) => key ) };
+		const warning = mount( AnonymousEditWarning, {
+			global: {
+				provide: {
+					[ ConfigKey as symbol ]: { isAnonymous: true },
+					[ MessagesKey as symbol ]: messages,
+				},
+			},
+		} );
+
+		expect( warning.html() ).toMatchSnapshot();
+		expect( messages.get ).toHaveBeenCalledWith( 'wikibase-anonymouseditwarning' );
+	} );
+
+} );

--- a/tests/unit/components/__snapshots__/AnonymousEditWarning.test.ts.snap
+++ b/tests/unit/components/__snapshots__/AnonymousEditWarning.test.ts.snap
@@ -1,7 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AnonymousEditWarning matches snapshot if anonymous 1`] = `
-"<!-- eslint-disable vue/no-v-html -->
-<p class=\\"wbl-snl-anonymous-edit-warning\\">wikibase-anonymouseditwarning</p>
-<!-- eslint-enable -->"
-`;
+exports[`AnonymousEditWarning matches snapshot if anonymous 1`] = `"<div class=\\"wikit wikit-Message wikit-Message--warning wbl-snl-anonymous-edit-warning\\"><span class=\\"wikit-Message__content\\"><span class=\\"wikit wikit-Icon wikit-Icon--large wikit-Icon--warning wikit-Message__icon\\"><svg class=\\"wikit-Icon__svg\\" xmlns=\\"http://www.w3.org/2000/svg\\" fill=\\"none\\" aria-hidden=\\"true\\" focusable=\\"false\\" viewBox=\\"0 0 16 16\\"><path fill=\\"currentColor\\" d=\\"M9.163 1.68234C9.06078 1.4381 8.89901 1.22746 8.69449 1.07231C8.48997 0.917151 8.25017 0.823144 7.99999 0.800049C7.75116 0.82453 7.51294 0.919178 7.30987 1.07425C7.10679 1.22933 6.94619 1.43922 6.84459 1.68234L0.672272 13.0631C0.0337565 14.2368 0.558251 15.2 1.82768 15.2H14.1723C15.4417 15.2 15.9662 14.2368 15.3277 13.0631L9.163 1.68234ZM8.76013 12.7717H7.23986V11.1528H8.76013V12.7717ZM8.76013 9.53394H7.23986V4.67728H8.76013V9.53394Z\\"></path></svg></span><span><!-- eslint-disable-next-line vue/no-v-html --><span>wikibase-anonymouseditwarning</span></span></span></div>"`;

--- a/tests/unit/components/__snapshots__/AnonymousEditWarning.test.ts.snap
+++ b/tests/unit/components/__snapshots__/AnonymousEditWarning.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AnonymousEditWarning matches snapshot if anonymous 1`] = `
+"<!-- eslint-disable vue/no-v-html -->
+<p class=\\"wbl-snl-anonymous-edit-warning\\">wikibase-anonymouseditwarning</p>
+<!-- eslint-enable -->"
+`;

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -16,6 +16,7 @@ describe( 'createAndMount', () => {
 
 		const instance = createAndMount( {
 			rootSelector: '#test-app',
+			isAnonymous: false,
 			licenseUrl: '',
 			licenseName: '',
 			wikibaseLexemeTermLanguages: new Map( [


### PR DESCRIPTION
Using the standard Wikibase message, but without passing an argument into it. Special:NewLexeme passes the wikibase-entity-lexeme message into it (the argument used to be used as a sort of “your IP address will be visible in the history of the item/property” thing), but that message doesn’t actually exist; the $1 argument is also only used in one remaining translation (vec/Venetian), where I’ve asked the translator to update the translation so it doesn’t use $1 anymore. Once that’s done, I expect we’ll update Wikibase and WikibaseLexeme to also drop this message parameter.

On the dev entry point, the warning can be seen by adding ?isAnonymous=true to the URL.

Bug: T313466