### PR TITLE
Add aria-required to lookup inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wmde/wikibase-datamodel-types": "^0.2.0",
-				"@wmde/wikit-tokens": "^3.0.0-alpha.6",
-				"@wmde/wikit-vue-components": "^3.0.0-alpha.6",
+				"@wmde/wikit-tokens": "^3.0.0-alpha.7",
+				"@wmde/wikit-vue-components": "^3.0.0-alpha.7",
 				"jest-environment-jsdom": "^28.1.3",
 				"vue": "^3.2.30",
 				"vuex": "^4.0.2"
@@ -2256,16 +2256,16 @@
 			"integrity": "sha512-ydQQPEDVmf/VCLPlCfwxV0hYqrA/9US91gSmtVaqvy9gGbyQK67x8AQFKTjdLR5rwoWsGpz8QU5wPWP1z5/56A=="
 		},
 		"node_modules/@wmde/wikit-tokens": {
-			"version": "3.0.0-alpha.6",
-			"resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.6.tgz",
-			"integrity": "sha512-oNB61nnE2DbwwFWgGWxh+1u9KciMrSyEq8lVvU663+K035bC96EOVpI8D/bqOQ2QxpRrEGRhYvzcXj9f3p8AXA=="
+			"version": "3.0.0-alpha.7",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.7.tgz",
+			"integrity": "sha512-iJ0o+AVL5voV/pPi94bAKwgWBDecC1p301JCmPIERz2DFjTPA7NiVSFgHXvlAtSwmNtj3J3S/lUjn6dtEuVWow=="
 		},
 		"node_modules/@wmde/wikit-vue-components": {
-			"version": "3.0.0-alpha.6",
-			"resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.6.tgz",
-			"integrity": "sha512-OZ+yJLNToX6GhAFAYgew8Er5+RtRCTTR9WyvglLXD/Pmx49I24Rbh1c6RbCx++k8Yry3aTB/LZAaE+5tDRU0Og==",
+			"version": "3.0.0-alpha.7",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.7.tgz",
+			"integrity": "sha512-2Jp9pn88p9k1P09P3j0Jep/101qbO4dhM4F6alunxsMGPiJdA24JlXxvzOBiQ3IVNDl2YyqkSrDfCCU4ZwTEcQ==",
 			"dependencies": {
-				"@wmde/wikit-tokens": "^3.0.0-alpha.6",
+				"@wmde/wikit-tokens": "^3.0.0-alpha.7",
 				"core-js": "^3.7.0",
 				"lodash.debounce": "^4.0.8",
 				"lodash.isequal": "^4.5.0",
@@ -14854,16 +14854,16 @@
 			"integrity": "sha512-ydQQPEDVmf/VCLPlCfwxV0hYqrA/9US91gSmtVaqvy9gGbyQK67x8AQFKTjdLR5rwoWsGpz8QU5wPWP1z5/56A=="
 		},
 		"@wmde/wikit-tokens": {
-			"version": "3.0.0-alpha.6",
-			"resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.6.tgz",
-			"integrity": "sha512-oNB61nnE2DbwwFWgGWxh+1u9KciMrSyEq8lVvU663+K035bC96EOVpI8D/bqOQ2QxpRrEGRhYvzcXj9f3p8AXA=="
+			"version": "3.0.0-alpha.7",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.7.tgz",
+			"integrity": "sha512-iJ0o+AVL5voV/pPi94bAKwgWBDecC1p301JCmPIERz2DFjTPA7NiVSFgHXvlAtSwmNtj3J3S/lUjn6dtEuVWow=="
 		},
 		"@wmde/wikit-vue-components": {
-			"version": "3.0.0-alpha.6",
-			"resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.6.tgz",
-			"integrity": "sha512-OZ+yJLNToX6GhAFAYgew8Er5+RtRCTTR9WyvglLXD/Pmx49I24Rbh1c6RbCx++k8Yry3aTB/LZAaE+5tDRU0Og==",
+			"version": "3.0.0-alpha.7",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.7.tgz",
+			"integrity": "sha512-2Jp9pn88p9k1P09P3j0Jep/101qbO4dhM4F6alunxsMGPiJdA24JlXxvzOBiQ3IVNDl2YyqkSrDfCCU4ZwTEcQ==",
 			"requires": {
-				"@wmde/wikit-tokens": "^3.0.0-alpha.6",
+				"@wmde/wikit-tokens": "^3.0.0-alpha.7",
 				"core-js": "^3.7.0",
 				"lodash.debounce": "^4.0.8",
 				"lodash.isequal": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
 	},
 	"dependencies": {
 		"@wmde/wikibase-datamodel-types": "^0.2.0",
-		"@wmde/wikit-tokens": "^3.0.0-alpha.6",
-		"@wmde/wikit-vue-components": "^3.0.0-alpha.6",
+		"@wmde/wikit-tokens": "^3.0.0-alpha.7",
+		"@wmde/wikit-vue-components": "^3.0.0-alpha.7",
 		"jest-environment-jsdom": "^28.1.3",
 		"vue": "^3.2.30",
 		"vuex": "^4.0.2"

--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -17,11 +17,13 @@ interface Props {
 	searchInput: string;
 	error?: { type: 'error'|'warning'; message: string } | null;
 	itemSuggestions?: SearchedItemOption[];
+	ariaRequired?: boolean;
 }
 const props = withDefaults( defineProps<Props>(), {
 	error: null,
 	itemSuggestions: () => [],
 	searchInput: '',
+	ariaRequired: false,
 } );
 
 const emit = defineEmits( {
@@ -140,6 +142,7 @@ const messages = useMessages();
 		:menu-items="wikitMenuItems"
 		:value="wikitValue"
 		:error="error"
+		:aria-required="ariaRequired"
 		@update:search-input="onSearchInput"
 		@scroll="onScroll"
 		@input="onWikitOptionSelected"

--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -66,6 +66,7 @@ export default {
 			:search-input="searchInput"
 			:search-for-items="searchForItems"
 			:error="error"
+			:aria-required="true"
 			@update:model-value="$emit( 'update:modelValue', $event )"
 			@update:search-input="$emit( 'update:searchInput', $event )"
 		/>

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -60,6 +60,7 @@ export default {
 			:search-for-items="searchForItems"
 			:item-suggestions="lexicalCategorySuggestions"
 			:error="error"
+			:aria-required="true"
 			@update:model-value="$emit( 'update:modelValue', $event )"
 			@update:search-input="$emit( 'update:searchInput', $event )"
 		/>

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -109,6 +109,7 @@ export default {
 		:menu-items="menuItems"
 		:value="selectedOption"
 		:error="error"
+		:aria-required="true"
 		@update:search-input="onSearchInput"
 		@input="onOptionSelected"
 	>

--- a/tests/unit/components/ItemLookup.test.ts
+++ b/tests/unit/components/ItemLookup.test.ts
@@ -262,6 +262,16 @@ describe( 'ItemLookup', () => {
 				},
 			] );
 		} );
+
+		it.each( [
+			[ false, 'false' ],
+			[ true, 'true' ],
+		] )( ':ariaRequired(%p)', ( propValue, attributeValue ) => {
+			const lookup = createLookup( { ariaRequired: propValue } );
+			const input = lookup.find( 'input' );
+
+			expect( input.attributes( 'aria-required' ) ).toBe( attributeValue );
+		} );
 	} );
 
 	describe( '@events', () => {

--- a/tests/unit/components/SpellingVariantInput.test.ts
+++ b/tests/unit/components/SpellingVariantInput.test.ts
@@ -166,4 +166,11 @@ describe( 'SpellingVariantInput', () => {
 
 		} );
 	} );
+
+	it( 'input is required', () => {
+		const lookup = createLookup();
+		const input = lookup.find( 'input' );
+
+		expect( input.attributes( 'aria-required' ) ).toBe( 'true' );
+	} );
 } );


### PR DESCRIPTION
We were already adding it to the lemma input; since Wikit 3.0.0-alpha.7, we can also add it to the other three inputs, which are lookups.

In the `ItemLookup` component, the `aria-required` is passed through as a new prop instead of hard-coded to true – all current item lookups are required, but in principle the component could be used for a non-required item lookup in future.

Note that we use `:aria-required="true"` instead of `aria-required="true"` to pass `true` as a boolean instead of a string.

Bug: T313891