### PR TITLE
Add asterisk to required form inputs

### DIFF
--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -150,5 +150,8 @@ const messages = useMessages();
 		<template #no-results>
 			{{ messages.getUnescaped( 'wikibase-entityselector-notfound' ) }}
 		</template>
+		<template #suffix>
+			<slot name="suffix" />
+		</template>
 	</wikit-lookup>
 </template>

--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -3,6 +3,7 @@ import { SearchedItemOption } from '@/data-access/ItemSearcher';
 import { useStore } from 'vuex';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import ItemLookup from '@/components/ItemLookup.vue';
+import RequiredAsterisk from '@/components/RequiredAsterisk.vue';
 import { useItemSearch } from '@/plugins/ItemSearchPlugin/ItemSearch';
 import { computed } from 'vue';
 import { useConfig } from '@/plugins/ConfigPlugin/Config';
@@ -69,6 +70,10 @@ export default {
 			:aria-required="true"
 			@update:model-value="$emit( 'update:modelValue', $event )"
 			@update:search-input="$emit( 'update:searchInput', $event )"
-		/>
+		>
+			<template #suffix>
+				<required-asterisk />
+			</template>
+		</item-lookup>
 	</div>
 </template>

--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { TextInput } from '@wmde/wikit-vue-components';
+import RequiredAsterisk from '@/components/RequiredAsterisk.vue';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import { useConfig } from '@/plugins/ConfigPlugin/Config';
 import { useStore } from 'vuex';
@@ -62,5 +63,9 @@ export default {
 		:error="error"
 		:value="modelValue"
 		@input="$emit( 'update:modelValue', $event )"
-	/>
+	>
+		<template #suffix>
+			<required-asterisk />
+		</template>
+	</text-input>
 </template>

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import ItemLookup from '@/components/ItemLookup.vue';
+import RequiredAsterisk from '@/components/RequiredAsterisk.vue';
 import { SearchedItemOption } from '@/data-access/ItemSearcher';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import { useItemSearch } from '@/plugins/ItemSearchPlugin/ItemSearch';
@@ -63,6 +64,10 @@ export default {
 			:aria-required="true"
 			@update:model-value="$emit( 'update:modelValue', $event )"
 			@update:search-input="$emit( 'update:searchInput', $event )"
-		/>
+		>
+			<template #suffix>
+				<required-asterisk />
+			</template>
+		</item-lookup>
 	</div>
 </template>

--- a/src/components/RequiredAsterisk.vue
+++ b/src/components/RequiredAsterisk.vue
@@ -1,0 +1,28 @@
+<script lang="ts">
+export default {
+	compatConfig: {
+		MODE: 3,
+	},
+};
+</script>
+
+<template>
+	<span
+		class="wbl-snl-required-asterisk"
+		aria-hidden="true"
+	>*</span>
+</template>
+
+<style lang="scss" scoped>
+@import "@wmde/wikit-tokens/variables";
+
+.wbl-snl-required-asterisk {
+	&:not(:first-child) {
+		margin-inline-start: $dimension-spacing-small;
+	}
+
+	&:not(:last-child) {
+		margin-inline-end: $dimension-spacing-small;
+	}
+}
+</style>

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue';
 import escapeRegExp from 'lodash/escapeRegExp';
 import WikitLookup from './WikitLookup';
 import { Link as WikitLink } from '@wmde/wikit-vue-components';
+import RequiredAsterisk from '@/components/RequiredAsterisk.vue';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import { useLanguageCodesProvider } from '@/plugins/LanguageCodesProviderPlugin/LanguageCodesProvider';
 import { useConfig } from '@/plugins/ConfigPlugin/Config';
@@ -117,6 +118,7 @@ export default {
 			{{ messages.getUnescaped( 'wikibase-entityselector-notfound' ) }}
 		</template>
 		<template #suffix>
+			<required-asterisk />
 			<span class="wbl-snl-spelling-variant-lookup__help-link">
 				<wikit-link :href="helpUrl" target="_blank">{{ helpLinkText }}</wikit-link>
 			</span>


### PR DESCRIPTION
The asterisk distances itself from anything else in the suffix slot using the same dimension as the gap between the label and the suffix as a whole; this is needed for the spelling variant input, where the suffix slot also contains a help link.

The asterisk is `aria-hidden` because we already mark the inputs themselves as `aria-required` and people don’t need two indications that the inputs are required.

Bug: T313892