### PR TITLE
Revert "Update vite to version 3.0.1 (#253)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@types/lodash": "^4.14.180",
 				"@typescript-eslint/eslint-plugin": "^5.31.0",
 				"@typescript-eslint/parser": "^5.31.0",
-				"@vitejs/plugin-vue": "^3.0.1",
+				"@vitejs/plugin-vue": "^2.1.0",
 				"@vue/eslint-config-typescript": "^11.0.0",
 				"@vue/test-utils": "v2.0.2",
 				"@vue/vue3-jest": "^28.0.0",
@@ -50,7 +50,7 @@
 				"stylelint-config-wikimedia": "^0.13.0",
 				"ts-jest": "^28.0.7",
 				"typescript": "^4.5.5",
-				"vite": "^3.0.3",
+				"vite": "^2.7.13",
 				"vite-plugin-banner": "^0.3.0",
 				"vue-tsc": "^0.39.0"
 			},
@@ -641,6 +641,22 @@
 			},
 			"engines": {
 				"node": "^12 || ^14 || ^16 || ^17"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.53.tgz",
+			"integrity": "sha512-W2dAL6Bnyn4xa/QRSU3ilIK4EzD5wgYXKXJiS1HDF5vU3675qc2bvFyLwbUcdmssDveyndy7FbitrCoiV/eMLg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
@@ -1962,15 +1978,15 @@
 			}
 		},
 		"node_modules/@vitejs/plugin-vue": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-3.0.1.tgz",
-			"integrity": "sha512-Ll9JgxG7ONIz/XZv3dssfoMUDu9qAnlJ+km+pBA0teYSXzwPCIzS/e1bmwNYl5dcQGs677D21amgfYAnzMl17A==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.3.tgz",
+			"integrity": "sha512-SmQLDyhz+6lGJhPELsBdzXGc+AcaT8stgkbiTFGpXPe8Tl1tJaBw1A6pxDqDuRsVkD8uscrkx3hA7QDOoKYtyw==",
 			"dev": true,
 			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
+				"node": ">=12.0.0"
 			},
 			"peerDependencies": {
-				"vite": "^3.0.0",
+				"vite": "^2.5.10",
 				"vue": "^3.2.25"
 			}
 		},
@@ -4172,9 +4188,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.50.tgz",
-			"integrity": "sha512-SbC3k35Ih2IC6trhbMYW7hYeGdjPKf9atTKwBUHqMCYFZZ9z8zhuvfnZihsnJypl74FjiAKjBRqFkBkAd0rS/w==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.53.tgz",
+			"integrity": "sha512-ohO33pUBQ64q6mmheX1mZ8mIXj8ivQY/L4oVuAshr+aJI+zLl+amrp3EodrUNDNYVrKJXGPfIHFGhO8slGRjuw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -4184,32 +4200,33 @@
 				"node": ">=12"
 			},
 			"optionalDependencies": {
-				"esbuild-android-64": "0.14.50",
-				"esbuild-android-arm64": "0.14.50",
-				"esbuild-darwin-64": "0.14.50",
-				"esbuild-darwin-arm64": "0.14.50",
-				"esbuild-freebsd-64": "0.14.50",
-				"esbuild-freebsd-arm64": "0.14.50",
-				"esbuild-linux-32": "0.14.50",
-				"esbuild-linux-64": "0.14.50",
-				"esbuild-linux-arm": "0.14.50",
-				"esbuild-linux-arm64": "0.14.50",
-				"esbuild-linux-mips64le": "0.14.50",
-				"esbuild-linux-ppc64le": "0.14.50",
-				"esbuild-linux-riscv64": "0.14.50",
-				"esbuild-linux-s390x": "0.14.50",
-				"esbuild-netbsd-64": "0.14.50",
-				"esbuild-openbsd-64": "0.14.50",
-				"esbuild-sunos-64": "0.14.50",
-				"esbuild-windows-32": "0.14.50",
-				"esbuild-windows-64": "0.14.50",
-				"esbuild-windows-arm64": "0.14.50"
+				"@esbuild/linux-loong64": "0.14.53",
+				"esbuild-android-64": "0.14.53",
+				"esbuild-android-arm64": "0.14.53",
+				"esbuild-darwin-64": "0.14.53",
+				"esbuild-darwin-arm64": "0.14.53",
+				"esbuild-freebsd-64": "0.14.53",
+				"esbuild-freebsd-arm64": "0.14.53",
+				"esbuild-linux-32": "0.14.53",
+				"esbuild-linux-64": "0.14.53",
+				"esbuild-linux-arm": "0.14.53",
+				"esbuild-linux-arm64": "0.14.53",
+				"esbuild-linux-mips64le": "0.14.53",
+				"esbuild-linux-ppc64le": "0.14.53",
+				"esbuild-linux-riscv64": "0.14.53",
+				"esbuild-linux-s390x": "0.14.53",
+				"esbuild-netbsd-64": "0.14.53",
+				"esbuild-openbsd-64": "0.14.53",
+				"esbuild-sunos-64": "0.14.53",
+				"esbuild-windows-32": "0.14.53",
+				"esbuild-windows-64": "0.14.53",
+				"esbuild-windows-arm64": "0.14.53"
 			}
 		},
 		"node_modules/esbuild-android-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.50.tgz",
-			"integrity": "sha512-H7iUEm7gUJHzidsBlFPGF6FTExazcgXL/46xxLo6i6bMtPim6ZmXyTccS8yOMpy6HAC6dPZ/JCQqrkkin69n6Q==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.53.tgz",
+			"integrity": "sha512-fIL93sOTnEU+NrTAVMIKiAw0YH22HWCAgg4N4Z6zov2t0kY9RAJ50zY9ZMCQ+RT6bnOfDt8gCTnt/RaSNA2yRA==",
 			"cpu": [
 				"x64"
 			],
@@ -4223,9 +4240,9 @@
 			}
 		},
 		"node_modules/esbuild-android-arm64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.50.tgz",
-			"integrity": "sha512-NFaoqEwa+OYfoYVpQWDMdKII7wZZkAjtJFo1WdnBeCYlYikvUhTnf2aPwPu5qEAw/ie1NYK0yn3cafwP+kP+OQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.53.tgz",
+			"integrity": "sha512-PC7KaF1v0h/nWpvlU1UMN7dzB54cBH8qSsm7S9mkwFA1BXpaEOufCg8hdoEI1jep0KeO/rjZVWrsH8+q28T77A==",
 			"cpu": [
 				"arm64"
 			],
@@ -4239,9 +4256,9 @@
 			}
 		},
 		"node_modules/esbuild-darwin-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.50.tgz",
-			"integrity": "sha512-gDQsCvGnZiJv9cfdO48QqxkRV8oKAXgR2CGp7TdIpccwFdJMHf8hyIJhMW/05b/HJjET/26Us27Jx91BFfEVSA==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.53.tgz",
+			"integrity": "sha512-gE7P5wlnkX4d4PKvLBUgmhZXvL7lzGRLri17/+CmmCzfncIgq8lOBvxGMiQ4xazplhxq+72TEohyFMZLFxuWvg==",
 			"cpu": [
 				"x64"
 			],
@@ -4255,9 +4272,9 @@
 			}
 		},
 		"node_modules/esbuild-darwin-arm64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.50.tgz",
-			"integrity": "sha512-36nNs5OjKIb/Q50Sgp8+rYW/PqirRiFN0NFc9hEvgPzNJxeJedktXwzfJSln4EcRFRh5Vz4IlqFRScp+aiBBzA==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.53.tgz",
+			"integrity": "sha512-otJwDU3hnI15Q98PX4MJbknSZ/WSR1I45il7gcxcECXzfN4Mrpft5hBDHXNRnCh+5858uPXBXA1Vaz2jVWLaIA==",
 			"cpu": [
 				"arm64"
 			],
@@ -4271,9 +4288,9 @@
 			}
 		},
 		"node_modules/esbuild-freebsd-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.50.tgz",
-			"integrity": "sha512-/1pHHCUem8e/R86/uR+4v5diI2CtBdiWKiqGuPa9b/0x3Nwdh5AOH7lj+8823C6uX1e0ufwkSLkS+aFZiBCWxA==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.53.tgz",
+			"integrity": "sha512-WkdJa8iyrGHyKiPF4lk0MiOF87Q2SkE+i+8D4Cazq3/iqmGPJ6u49je300MFi5I2eUsQCkaOWhpCVQMTKGww2w==",
 			"cpu": [
 				"x64"
 			],
@@ -4287,9 +4304,9 @@
 			}
 		},
 		"node_modules/esbuild-freebsd-arm64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.50.tgz",
-			"integrity": "sha512-iKwUVMQztnPZe5pUYHdMkRc9aSpvoV1mkuHlCoPtxZA3V+Kg/ptpzkcSY+fKd0kuom+l6Rc93k0UPVkP7xoqrw==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.53.tgz",
+			"integrity": "sha512-9T7WwCuV30NAx0SyQpw8edbKvbKELnnm1FHg7gbSYaatH+c8WJW10g/OdM7JYnv7qkimw2ZTtSA+NokOLd2ydQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -4303,9 +4320,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-32": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.50.tgz",
-			"integrity": "sha512-sWUwvf3uz7dFOpLzYuih+WQ7dRycrBWHCdoXJ4I4XdMxEHCECd8b7a9N9u7FzT6XR2gHPk9EzvchQUtiEMRwqw==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.53.tgz",
+			"integrity": "sha512-VGanLBg5en2LfGDgLEUxQko2lqsOS7MTEWUi8x91YmsHNyzJVT/WApbFFx3MQGhkf+XdimVhpyo5/G0PBY91zg==",
 			"cpu": [
 				"ia32"
 			],
@@ -4319,9 +4336,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.50.tgz",
-			"integrity": "sha512-u0PQxPhaeI629t4Y3EEcQ0wmWG+tC/LpP2K7yDFvwuPq0jSQ8SIN+ARNYfRjGW15O2we3XJvklbGV0wRuUCPig==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.53.tgz",
+			"integrity": "sha512-pP/FA55j/fzAV7N9DF31meAyjOH6Bjuo3aSKPh26+RW85ZEtbJv9nhoxmGTd9FOqjx59Tc1ZbrJabuiXlMwuZQ==",
 			"cpu": [
 				"x64"
 			],
@@ -4335,9 +4352,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-arm": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.50.tgz",
-			"integrity": "sha512-VALZq13bhmFJYFE/mLEb+9A0w5vo8z+YDVOWeaf9vOTrSC31RohRIwtxXBnVJ7YKLYfEMzcgFYf+OFln3Y0cWg==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.53.tgz",
+			"integrity": "sha512-/u81NGAVZMopbmzd21Nu/wvnKQK3pT4CrvQ8BTje1STXcQAGnfyKgQlj3m0j2BzYbvQxSy+TMck4TNV2onvoPA==",
 			"cpu": [
 				"arm"
 			],
@@ -4351,9 +4368,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-arm64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.50.tgz",
-			"integrity": "sha512-ZyfoNgsTftD7Rp5S7La5auomKdNeB3Ck+kSKXC4pp96VnHyYGjHHXWIlcbH8i+efRn9brszo1/Thl1qn8RqmhQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.53.tgz",
+			"integrity": "sha512-GDmWITT+PMsjCA6/lByYk7NyFssW4Q6in32iPkpjZ/ytSyH+xeEx8q7HG3AhWH6heemEYEWpTll/eui3jwlSnw==",
 			"cpu": [
 				"arm64"
 			],
@@ -4367,9 +4384,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-mips64le": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.50.tgz",
-			"integrity": "sha512-ygo31Vxn/WrmjKCHkBoutOlFG5yM9J2UhzHb0oWD9O61dGg+Hzjz9hjf5cmM7FBhAzdpOdEWHIrVOg2YAi6rTw==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.53.tgz",
+			"integrity": "sha512-d6/XHIQW714gSSp6tOOX2UscedVobELvQlPMkInhx1NPz4ThZI9uNLQ4qQJHGBGKGfu+rtJsxM4NVHLhnNRdWQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -4383,9 +4400,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-ppc64le": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.50.tgz",
-			"integrity": "sha512-xWCKU5UaiTUT6Wz/O7GKP9KWdfbsb7vhfgQzRfX4ahh5NZV4ozZ4+SdzYG8WxetsLy84UzLX3Pi++xpVn1OkFQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.53.tgz",
+			"integrity": "sha512-ndnJmniKPCB52m+r6BtHHLAOXw+xBCWIxNnedbIpuREOcbSU/AlyM/2dA3BmUQhsHdb4w3amD5U2s91TJ3MzzA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -4399,9 +4416,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-riscv64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.50.tgz",
-			"integrity": "sha512-0+dsneSEihZTopoO9B6Z6K4j3uI7EdxBP7YSF5rTwUgCID+wHD3vM1gGT0m+pjCW+NOacU9kH/WE9N686FHAJg==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.53.tgz",
+			"integrity": "sha512-yG2sVH+QSix6ct4lIzJj329iJF3MhloLE6/vKMQAAd26UVPVkhMFqFopY+9kCgYsdeWvXdPgmyOuKa48Y7+/EQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -4415,9 +4432,9 @@
 			}
 		},
 		"node_modules/esbuild-linux-s390x": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.50.tgz",
-			"integrity": "sha512-tVjqcu8o0P9H4StwbIhL1sQYm5mWATlodKB6dpEZFkcyTI8kfIGWiWcrGmkNGH2i1kBUOsdlBafPxR3nzp3TDA==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.53.tgz",
+			"integrity": "sha512-OCJlgdkB+XPYndHmw6uZT7jcYgzmx9K+28PVdOa/eLjdoYkeAFvH5hTwX4AXGLZLH09tpl4bVsEtvuyUldaNCg==",
 			"cpu": [
 				"s390x"
 			],
@@ -4431,9 +4448,9 @@
 			}
 		},
 		"node_modules/esbuild-netbsd-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.50.tgz",
-			"integrity": "sha512-0R/glfqAQ2q6MHDf7YJw/TulibugjizBxyPvZIcorH0Mb7vSimdHy0XF5uCba5CKt+r4wjax1mvO9lZ4jiAhEg==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.53.tgz",
+			"integrity": "sha512-gp2SB+Efc7MhMdWV2+pmIs/Ja/Mi5rjw+wlDmmbIn68VGXBleNgiEZG+eV2SRS0kJEUyHNedDtwRIMzaohWedQ==",
 			"cpu": [
 				"x64"
 			],
@@ -4447,9 +4464,9 @@
 			}
 		},
 		"node_modules/esbuild-openbsd-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.50.tgz",
-			"integrity": "sha512-7PAtmrR5mDOFubXIkuxYQ4bdNS6XCK8AIIHUiZxq1kL8cFIH5731jPcXQ4JNy/wbj1C9sZ8rzD8BIM80Tqk29w==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.53.tgz",
+			"integrity": "sha512-eKQ30ZWe+WTZmteDYg8S+YjHV5s4iTxeSGhJKJajFfQx9TLZJvsJX0/paqwP51GicOUruFpSUAs2NCc0a4ivQQ==",
 			"cpu": [
 				"x64"
 			],
@@ -4463,9 +4480,9 @@
 			}
 		},
 		"node_modules/esbuild-sunos-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.50.tgz",
-			"integrity": "sha512-gBxNY/wyptvD7PkHIYcq7se6SQEXcSC8Y7mE0FJB+CGgssEWf6vBPfTTZ2b6BWKnmaP6P6qb7s/KRIV5T2PxsQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.53.tgz",
+			"integrity": "sha512-OWLpS7a2FrIRukQqcgQqR1XKn0jSJoOdT+RlhAxUoEQM/IpytS3FXzCJM6xjUYtpO5GMY0EdZJp+ur2pYdm39g==",
 			"cpu": [
 				"x64"
 			],
@@ -4479,9 +4496,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-32": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.50.tgz",
-			"integrity": "sha512-MOOe6J9cqe/iW1qbIVYSAqzJFh0p2LBLhVUIWdMVnNUNjvg2/4QNX4oT4IzgDeldU+Bym9/Tn6+DxvUHJXL5Zw==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.53.tgz",
+			"integrity": "sha512-m14XyWQP5rwGW0tbEfp95U6A0wY0DYPInWBB7D69FAXUpBpBObRoGTKRv36lf2RWOdE4YO3TNvj37zhXjVL5xg==",
 			"cpu": [
 				"ia32"
 			],
@@ -4495,9 +4512,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.50.tgz",
-			"integrity": "sha512-r/qE5Ex3w1jjGv/JlpPoWB365ldkppUlnizhMxJgojp907ZF1PgLTuW207kgzZcSCXyquL9qJkMsY+MRtaZ5yQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.53.tgz",
+			"integrity": "sha512-s9skQFF0I7zqnQ2K8S1xdLSfZFsPLuOGmSx57h2btSEswv0N0YodYvqLcJMrNMXh6EynOmWD7rz+0rWWbFpIHQ==",
 			"cpu": [
 				"x64"
 			],
@@ -4511,9 +4528,9 @@
 			}
 		},
 		"node_modules/esbuild-windows-arm64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.50.tgz",
-			"integrity": "sha512-EMS4lQnsIe12ZyAinOINx7eq2mjpDdhGZZWDwPZE/yUTN9cnc2Ze/xUTYIAyaJqrqQda3LnDpADKpvLvol6ENQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.53.tgz",
+			"integrity": "sha512-E+5Gvb+ZWts+00T9II6wp2L3KG2r3iGxByqd/a1RmLmYWVsSVUjkvIxZuJ3hYTIbhLkH5PRwpldGTKYqVz0nzQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -11088,9 +11105,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.77.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.1.tgz",
-			"integrity": "sha512-GhutNJrvTYD6s1moo+kyq7lD9DeR5HDyXo4bDFlDSkepC9kVKY+KK/NSZFzCmeXeia3kEzVuToQmHRdugyZHxw==",
+			"version": "2.77.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
+			"integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -12667,21 +12684,21 @@
 			"dev": true
 		},
 		"node_modules/vite": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.0.3.tgz",
-			"integrity": "sha512-sDIpIcl3mv1NUaSzZwiXGEy1ZoWwwC2vkxUHY6yiDacR6zf//ZFuBJrozO62gedpE43pmxnLATNR5IYUdAEkMQ==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.14.tgz",
+			"integrity": "sha512-P/UCjSpSMcE54r4mPak55hWAZPlyfS369svib/gpmz8/01L822lMPOJ/RYW6tLCe1RPvMvOsJ17erf55bKp4Hw==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.14.47",
-				"postcss": "^8.4.14",
-				"resolve": "^1.22.1",
-				"rollup": "^2.75.6"
+				"esbuild": "^0.14.27",
+				"postcss": "^8.4.13",
+				"resolve": "^1.22.0",
+				"rollup": "^2.59.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": "^14.18.0 || >=16.0.0"
+				"node": ">=12.2.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
@@ -12689,8 +12706,7 @@
 			"peerDependencies": {
 				"less": "*",
 				"sass": "*",
-				"stylus": "*",
-				"terser": "^5.4.0"
+				"stylus": "*"
 			},
 			"peerDependenciesMeta": {
 				"less": {
@@ -12700,9 +12716,6 @@
 					"optional": true
 				},
 				"stylus": {
-					"optional": true
-				},
-				"terser": {
 					"optional": true
 				}
 			}
@@ -13595,6 +13608,13 @@
 				"esquery": "^1.4.0",
 				"jsdoc-type-pratt-parser": "~2.2.3"
 			}
+		},
+		"@esbuild/linux-loong64": {
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.14.53.tgz",
+			"integrity": "sha512-W2dAL6Bnyn4xa/QRSU3ilIK4EzD5wgYXKXJiS1HDF5vU3675qc2bvFyLwbUcdmssDveyndy7FbitrCoiV/eMLg==",
+			"dev": true,
+			"optional": true
 		},
 		"@eslint/eslintrc": {
 			"version": "1.3.0",
@@ -14613,9 +14633,9 @@
 			}
 		},
 		"@vitejs/plugin-vue": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-3.0.1.tgz",
-			"integrity": "sha512-Ll9JgxG7ONIz/XZv3dssfoMUDu9qAnlJ+km+pBA0teYSXzwPCIzS/e1bmwNYl5dcQGs677D21amgfYAnzMl17A==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-2.3.3.tgz",
+			"integrity": "sha512-SmQLDyhz+6lGJhPELsBdzXGc+AcaT8stgkbiTFGpXPe8Tl1tJaBw1A6pxDqDuRsVkD8uscrkx3hA7QDOoKYtyw==",
 			"dev": true,
 			"requires": {}
 		},
@@ -16299,170 +16319,171 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.50.tgz",
-			"integrity": "sha512-SbC3k35Ih2IC6trhbMYW7hYeGdjPKf9atTKwBUHqMCYFZZ9z8zhuvfnZihsnJypl74FjiAKjBRqFkBkAd0rS/w==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.53.tgz",
+			"integrity": "sha512-ohO33pUBQ64q6mmheX1mZ8mIXj8ivQY/L4oVuAshr+aJI+zLl+amrp3EodrUNDNYVrKJXGPfIHFGhO8slGRjuw==",
 			"dev": true,
 			"requires": {
-				"esbuild-android-64": "0.14.50",
-				"esbuild-android-arm64": "0.14.50",
-				"esbuild-darwin-64": "0.14.50",
-				"esbuild-darwin-arm64": "0.14.50",
-				"esbuild-freebsd-64": "0.14.50",
-				"esbuild-freebsd-arm64": "0.14.50",
-				"esbuild-linux-32": "0.14.50",
-				"esbuild-linux-64": "0.14.50",
-				"esbuild-linux-arm": "0.14.50",
-				"esbuild-linux-arm64": "0.14.50",
-				"esbuild-linux-mips64le": "0.14.50",
-				"esbuild-linux-ppc64le": "0.14.50",
-				"esbuild-linux-riscv64": "0.14.50",
-				"esbuild-linux-s390x": "0.14.50",
-				"esbuild-netbsd-64": "0.14.50",
-				"esbuild-openbsd-64": "0.14.50",
-				"esbuild-sunos-64": "0.14.50",
-				"esbuild-windows-32": "0.14.50",
-				"esbuild-windows-64": "0.14.50",
-				"esbuild-windows-arm64": "0.14.50"
+				"@esbuild/linux-loong64": "0.14.53",
+				"esbuild-android-64": "0.14.53",
+				"esbuild-android-arm64": "0.14.53",
+				"esbuild-darwin-64": "0.14.53",
+				"esbuild-darwin-arm64": "0.14.53",
+				"esbuild-freebsd-64": "0.14.53",
+				"esbuild-freebsd-arm64": "0.14.53",
+				"esbuild-linux-32": "0.14.53",
+				"esbuild-linux-64": "0.14.53",
+				"esbuild-linux-arm": "0.14.53",
+				"esbuild-linux-arm64": "0.14.53",
+				"esbuild-linux-mips64le": "0.14.53",
+				"esbuild-linux-ppc64le": "0.14.53",
+				"esbuild-linux-riscv64": "0.14.53",
+				"esbuild-linux-s390x": "0.14.53",
+				"esbuild-netbsd-64": "0.14.53",
+				"esbuild-openbsd-64": "0.14.53",
+				"esbuild-sunos-64": "0.14.53",
+				"esbuild-windows-32": "0.14.53",
+				"esbuild-windows-64": "0.14.53",
+				"esbuild-windows-arm64": "0.14.53"
 			}
 		},
 		"esbuild-android-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.50.tgz",
-			"integrity": "sha512-H7iUEm7gUJHzidsBlFPGF6FTExazcgXL/46xxLo6i6bMtPim6ZmXyTccS8yOMpy6HAC6dPZ/JCQqrkkin69n6Q==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.53.tgz",
+			"integrity": "sha512-fIL93sOTnEU+NrTAVMIKiAw0YH22HWCAgg4N4Z6zov2t0kY9RAJ50zY9ZMCQ+RT6bnOfDt8gCTnt/RaSNA2yRA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-android-arm64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.50.tgz",
-			"integrity": "sha512-NFaoqEwa+OYfoYVpQWDMdKII7wZZkAjtJFo1WdnBeCYlYikvUhTnf2aPwPu5qEAw/ie1NYK0yn3cafwP+kP+OQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.53.tgz",
+			"integrity": "sha512-PC7KaF1v0h/nWpvlU1UMN7dzB54cBH8qSsm7S9mkwFA1BXpaEOufCg8hdoEI1jep0KeO/rjZVWrsH8+q28T77A==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.50.tgz",
-			"integrity": "sha512-gDQsCvGnZiJv9cfdO48QqxkRV8oKAXgR2CGp7TdIpccwFdJMHf8hyIJhMW/05b/HJjET/26Us27Jx91BFfEVSA==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.53.tgz",
+			"integrity": "sha512-gE7P5wlnkX4d4PKvLBUgmhZXvL7lzGRLri17/+CmmCzfncIgq8lOBvxGMiQ4xazplhxq+72TEohyFMZLFxuWvg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-darwin-arm64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.50.tgz",
-			"integrity": "sha512-36nNs5OjKIb/Q50Sgp8+rYW/PqirRiFN0NFc9hEvgPzNJxeJedktXwzfJSln4EcRFRh5Vz4IlqFRScp+aiBBzA==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.53.tgz",
+			"integrity": "sha512-otJwDU3hnI15Q98PX4MJbknSZ/WSR1I45il7gcxcECXzfN4Mrpft5hBDHXNRnCh+5858uPXBXA1Vaz2jVWLaIA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.50.tgz",
-			"integrity": "sha512-/1pHHCUem8e/R86/uR+4v5diI2CtBdiWKiqGuPa9b/0x3Nwdh5AOH7lj+8823C6uX1e0ufwkSLkS+aFZiBCWxA==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.53.tgz",
+			"integrity": "sha512-WkdJa8iyrGHyKiPF4lk0MiOF87Q2SkE+i+8D4Cazq3/iqmGPJ6u49je300MFi5I2eUsQCkaOWhpCVQMTKGww2w==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-freebsd-arm64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.50.tgz",
-			"integrity": "sha512-iKwUVMQztnPZe5pUYHdMkRc9aSpvoV1mkuHlCoPtxZA3V+Kg/ptpzkcSY+fKd0kuom+l6Rc93k0UPVkP7xoqrw==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.53.tgz",
+			"integrity": "sha512-9T7WwCuV30NAx0SyQpw8edbKvbKELnnm1FHg7gbSYaatH+c8WJW10g/OdM7JYnv7qkimw2ZTtSA+NokOLd2ydQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-32": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.50.tgz",
-			"integrity": "sha512-sWUwvf3uz7dFOpLzYuih+WQ7dRycrBWHCdoXJ4I4XdMxEHCECd8b7a9N9u7FzT6XR2gHPk9EzvchQUtiEMRwqw==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.53.tgz",
+			"integrity": "sha512-VGanLBg5en2LfGDgLEUxQko2lqsOS7MTEWUi8x91YmsHNyzJVT/WApbFFx3MQGhkf+XdimVhpyo5/G0PBY91zg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.50.tgz",
-			"integrity": "sha512-u0PQxPhaeI629t4Y3EEcQ0wmWG+tC/LpP2K7yDFvwuPq0jSQ8SIN+ARNYfRjGW15O2we3XJvklbGV0wRuUCPig==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.53.tgz",
+			"integrity": "sha512-pP/FA55j/fzAV7N9DF31meAyjOH6Bjuo3aSKPh26+RW85ZEtbJv9nhoxmGTd9FOqjx59Tc1ZbrJabuiXlMwuZQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.50.tgz",
-			"integrity": "sha512-VALZq13bhmFJYFE/mLEb+9A0w5vo8z+YDVOWeaf9vOTrSC31RohRIwtxXBnVJ7YKLYfEMzcgFYf+OFln3Y0cWg==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.53.tgz",
+			"integrity": "sha512-/u81NGAVZMopbmzd21Nu/wvnKQK3pT4CrvQ8BTje1STXcQAGnfyKgQlj3m0j2BzYbvQxSy+TMck4TNV2onvoPA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-arm64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.50.tgz",
-			"integrity": "sha512-ZyfoNgsTftD7Rp5S7La5auomKdNeB3Ck+kSKXC4pp96VnHyYGjHHXWIlcbH8i+efRn9brszo1/Thl1qn8RqmhQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.53.tgz",
+			"integrity": "sha512-GDmWITT+PMsjCA6/lByYk7NyFssW4Q6in32iPkpjZ/ytSyH+xeEx8q7HG3AhWH6heemEYEWpTll/eui3jwlSnw==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-mips64le": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.50.tgz",
-			"integrity": "sha512-ygo31Vxn/WrmjKCHkBoutOlFG5yM9J2UhzHb0oWD9O61dGg+Hzjz9hjf5cmM7FBhAzdpOdEWHIrVOg2YAi6rTw==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.53.tgz",
+			"integrity": "sha512-d6/XHIQW714gSSp6tOOX2UscedVobELvQlPMkInhx1NPz4ThZI9uNLQ4qQJHGBGKGfu+rtJsxM4NVHLhnNRdWQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-ppc64le": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.50.tgz",
-			"integrity": "sha512-xWCKU5UaiTUT6Wz/O7GKP9KWdfbsb7vhfgQzRfX4ahh5NZV4ozZ4+SdzYG8WxetsLy84UzLX3Pi++xpVn1OkFQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.53.tgz",
+			"integrity": "sha512-ndnJmniKPCB52m+r6BtHHLAOXw+xBCWIxNnedbIpuREOcbSU/AlyM/2dA3BmUQhsHdb4w3amD5U2s91TJ3MzzA==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-riscv64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.50.tgz",
-			"integrity": "sha512-0+dsneSEihZTopoO9B6Z6K4j3uI7EdxBP7YSF5rTwUgCID+wHD3vM1gGT0m+pjCW+NOacU9kH/WE9N686FHAJg==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.53.tgz",
+			"integrity": "sha512-yG2sVH+QSix6ct4lIzJj329iJF3MhloLE6/vKMQAAd26UVPVkhMFqFopY+9kCgYsdeWvXdPgmyOuKa48Y7+/EQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-linux-s390x": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.50.tgz",
-			"integrity": "sha512-tVjqcu8o0P9H4StwbIhL1sQYm5mWATlodKB6dpEZFkcyTI8kfIGWiWcrGmkNGH2i1kBUOsdlBafPxR3nzp3TDA==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.53.tgz",
+			"integrity": "sha512-OCJlgdkB+XPYndHmw6uZT7jcYgzmx9K+28PVdOa/eLjdoYkeAFvH5hTwX4AXGLZLH09tpl4bVsEtvuyUldaNCg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-netbsd-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.50.tgz",
-			"integrity": "sha512-0R/glfqAQ2q6MHDf7YJw/TulibugjizBxyPvZIcorH0Mb7vSimdHy0XF5uCba5CKt+r4wjax1mvO9lZ4jiAhEg==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.53.tgz",
+			"integrity": "sha512-gp2SB+Efc7MhMdWV2+pmIs/Ja/Mi5rjw+wlDmmbIn68VGXBleNgiEZG+eV2SRS0kJEUyHNedDtwRIMzaohWedQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-openbsd-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.50.tgz",
-			"integrity": "sha512-7PAtmrR5mDOFubXIkuxYQ4bdNS6XCK8AIIHUiZxq1kL8cFIH5731jPcXQ4JNy/wbj1C9sZ8rzD8BIM80Tqk29w==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.53.tgz",
+			"integrity": "sha512-eKQ30ZWe+WTZmteDYg8S+YjHV5s4iTxeSGhJKJajFfQx9TLZJvsJX0/paqwP51GicOUruFpSUAs2NCc0a4ivQQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-sunos-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.50.tgz",
-			"integrity": "sha512-gBxNY/wyptvD7PkHIYcq7se6SQEXcSC8Y7mE0FJB+CGgssEWf6vBPfTTZ2b6BWKnmaP6P6qb7s/KRIV5T2PxsQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.53.tgz",
+			"integrity": "sha512-OWLpS7a2FrIRukQqcgQqR1XKn0jSJoOdT+RlhAxUoEQM/IpytS3FXzCJM6xjUYtpO5GMY0EdZJp+ur2pYdm39g==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-32": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.50.tgz",
-			"integrity": "sha512-MOOe6J9cqe/iW1qbIVYSAqzJFh0p2LBLhVUIWdMVnNUNjvg2/4QNX4oT4IzgDeldU+Bym9/Tn6+DxvUHJXL5Zw==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.53.tgz",
+			"integrity": "sha512-m14XyWQP5rwGW0tbEfp95U6A0wY0DYPInWBB7D69FAXUpBpBObRoGTKRv36lf2RWOdE4YO3TNvj37zhXjVL5xg==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.50.tgz",
-			"integrity": "sha512-r/qE5Ex3w1jjGv/JlpPoWB365ldkppUlnizhMxJgojp907ZF1PgLTuW207kgzZcSCXyquL9qJkMsY+MRtaZ5yQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.53.tgz",
+			"integrity": "sha512-s9skQFF0I7zqnQ2K8S1xdLSfZFsPLuOGmSx57h2btSEswv0N0YodYvqLcJMrNMXh6EynOmWD7rz+0rWWbFpIHQ==",
 			"dev": true,
 			"optional": true
 		},
 		"esbuild-windows-arm64": {
-			"version": "0.14.50",
-			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.50.tgz",
-			"integrity": "sha512-EMS4lQnsIe12ZyAinOINx7eq2mjpDdhGZZWDwPZE/yUTN9cnc2Ze/xUTYIAyaJqrqQda3LnDpADKpvLvol6ENQ==",
+			"version": "0.14.53",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.53.tgz",
+			"integrity": "sha512-E+5Gvb+ZWts+00T9II6wp2L3KG2r3iGxByqd/a1RmLmYWVsSVUjkvIxZuJ3hYTIbhLkH5PRwpldGTKYqVz0nzQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -21218,9 +21239,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.77.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.1.tgz",
-			"integrity": "sha512-GhutNJrvTYD6s1moo+kyq7lD9DeR5HDyXo4bDFlDSkepC9kVKY+KK/NSZFzCmeXeia3kEzVuToQmHRdugyZHxw==",
+			"version": "2.77.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.2.tgz",
+			"integrity": "sha512-m/4YzYgLcpMQbxX3NmAqDvwLATZzxt8bIegO78FZLl+lAgKJBd1DRAOeEiZcKOIOPjxE6ewHWHNgGEalFXuz1g==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -22409,16 +22430,16 @@
 			}
 		},
 		"vite": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-3.0.3.tgz",
-			"integrity": "sha512-sDIpIcl3mv1NUaSzZwiXGEy1ZoWwwC2vkxUHY6yiDacR6zf//ZFuBJrozO62gedpE43pmxnLATNR5IYUdAEkMQ==",
+			"version": "2.9.14",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.9.14.tgz",
+			"integrity": "sha512-P/UCjSpSMcE54r4mPak55hWAZPlyfS369svib/gpmz8/01L822lMPOJ/RYW6tLCe1RPvMvOsJ17erf55bKp4Hw==",
 			"dev": true,
 			"requires": {
-				"esbuild": "^0.14.47",
+				"esbuild": "^0.14.27",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.4.14",
-				"resolve": "^1.22.1",
-				"rollup": "^2.75.6"
+				"postcss": "^8.4.13",
+				"resolve": "^1.22.0",
+				"rollup": "^2.59.0"
 			}
 		},
 		"vite-plugin-banner": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"@types/lodash": "^4.14.180",
 		"@typescript-eslint/eslint-plugin": "^5.31.0",
 		"@typescript-eslint/parser": "^5.31.0",
-		"@vitejs/plugin-vue": "^3.0.1",
+		"@vitejs/plugin-vue": "^2.1.0",
 		"@vue/eslint-config-typescript": "^11.0.0",
 		"@vue/test-utils": "v2.0.2",
 		"@vue/vue3-jest": "^28.0.0",
@@ -84,7 +84,7 @@
 		"stylelint-config-wikimedia": "^0.13.0",
 		"ts-jest": "^28.0.7",
 		"typescript": "^4.5.5",
-		"vite": "^3.0.3",
+		"vite": "^2.7.13",
 		"vite-plugin-banner": "^0.3.0",
 		"vue-tsc": "^0.39.0"
 	},


### PR DESCRIPTION
Vite 3 requires Node v14.18 or higher, which we don’t have in CI yet.

This reverts commit 8bfc8b5518fb9c0def31f9f94a6578cf8ae53c4e.