### PR TITLE
Style adjustments

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -12,6 +12,7 @@
 			"namespaces": ["wbl-snl-"]
 		},
 		"indentation": "tab",
-		"selector-max-id": 1
+		"selector-max-id": 1,
+		"unit-disallowed-list": null
 	}
 }

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -213,6 +213,7 @@ export default {
 
 	font-size: 0.8125rem;
 	font-style: italic;
+	margin-bottom: 0;
 }
 
 </style>

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -211,6 +211,7 @@ export default {
 .wbl-snl-copyright {
 	@include small-text;
 
+	font-size: 0.8125rem;
 	font-style: italic;
 }
 

--- a/src/components/SearchExisting.vue
+++ b/src/components/SearchExisting.vue
@@ -29,5 +29,8 @@ const searchMessage = computed( () => messages.get(
 
 .wbl-snl-search-existing {
 	@include body;
+
+	margin-top: 1rem;
+	margin-bottom: 1rem;
 }
 </style>

--- a/src/components/WarningMessage.vue
+++ b/src/components/WarningMessage.vue
@@ -7,3 +7,10 @@ import { Message as WikitMessage } from '@wmde/wikit-vue-components';
 		<slot />
 	</wikit-message>
 </template>
+
+<style lang="scss" scoped>
+.wbl-snl-anonymous-edit-warning {
+	margin-top: 1rem;
+	margin-bottom: 1rem;
+}
+</style>


### PR DESCRIPTION
The linter rule does not allow using 'rem' as a unit,
i've disabled it.
font-size for the copyright message should be 13px, the
rem in this case is relativly calculated from 1rem which is 16px.
margins between elements adapted to represent 16px as well.
The main content wrapper will get a top margin of 0.5rem
so that the gap between search-exiting or anonymous edit message
and the main form always remains 1.5rem.

Bug: T312652