### PR TITLE
Remove GITHUB_TOKEN from comment-pull-request action

### DIFF
--- a/.github/workflows/comment-deploy-url-to-pr.yaml
+++ b/.github/workflows/comment-deploy-url-to-pr.yaml
@@ -17,4 +17,3 @@ jobs:
               uses: thollander/actions-comment-pull-request@v1.5.0
               with:
                   message: "<https://${{ steps.get_hash.outputs.hash }}--new-lexeme-special-page.netlify.app>"
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is no longer needed (it grabs the token on its own).