### PR TITLE
Move inputs and Create-Lexeme button to the front of the taborder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wmde/wikibase-datamodel-types": "^0.2.0",
-				"@wmde/wikit-tokens": "^3.0.0-alpha.8",
-				"@wmde/wikit-vue-components": "^3.0.0-alpha.8",
+				"@wmde/wikit-tokens": "^3.0.0-alpha.9",
+				"@wmde/wikit-vue-components": "^3.0.0-alpha.9",
 				"jest-environment-jsdom": "^29.2.2",
 				"vue": "^3.2.38",
 				"vuex": "^4.0.2"
@@ -2484,16 +2484,16 @@
 			"integrity": "sha512-ydQQPEDVmf/VCLPlCfwxV0hYqrA/9US91gSmtVaqvy9gGbyQK67x8AQFKTjdLR5rwoWsGpz8QU5wPWP1z5/56A=="
 		},
 		"node_modules/@wmde/wikit-tokens": {
-			"version": "3.0.0-alpha.8",
-			"resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.8.tgz",
-			"integrity": "sha512-8Ot9CACAYivD03gycKVWPCzw+FYmOQaqPO0tkzrSlFtJZl++S//qD3ZIShFy8Kr6Ef3NhAYDiDbE15egFaknQw=="
+			"version": "3.0.0-alpha.9",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.9.tgz",
+			"integrity": "sha512-SIVOvgKAw1kDChNOn3lrdF/DGXAzX4k90L6nquATbpJJlgOWbTeLdJ6gpQLb1HG/n47UjXDFsUs6oqRywAdj6w=="
 		},
 		"node_modules/@wmde/wikit-vue-components": {
-			"version": "3.0.0-alpha.8",
-			"resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.8.tgz",
-			"integrity": "sha512-78PUZQzlxnzLZVo0qWDq9f3U1X2Q3GY7CpMvEff8ipx97fWXOaXYekIfhliJJrdka1Yz6gIIPxFwlmaqstNx8g==",
+			"version": "3.0.0-alpha.9",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.9.tgz",
+			"integrity": "sha512-3rUZjg0v+IBEX2uSbYcPACcTn3fHlnvuYxqNdJMqT2/E4lw/id/nZgTdRSZiLFCLj/isNzmcWYWl9x7cpM/mfA==",
 			"dependencies": {
-				"@wmde/wikit-tokens": "^3.0.0-alpha.8",
+				"@wmde/wikit-tokens": "^3.0.0-alpha.9",
 				"core-js": "^3.7.0",
 				"lodash.debounce": "^4.0.8",
 				"lodash.isequal": "^4.5.0",
@@ -15300,16 +15300,16 @@
 			"integrity": "sha512-ydQQPEDVmf/VCLPlCfwxV0hYqrA/9US91gSmtVaqvy9gGbyQK67x8AQFKTjdLR5rwoWsGpz8QU5wPWP1z5/56A=="
 		},
 		"@wmde/wikit-tokens": {
-			"version": "3.0.0-alpha.8",
-			"resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.8.tgz",
-			"integrity": "sha512-8Ot9CACAYivD03gycKVWPCzw+FYmOQaqPO0tkzrSlFtJZl++S//qD3ZIShFy8Kr6Ef3NhAYDiDbE15egFaknQw=="
+			"version": "3.0.0-alpha.9",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-tokens/-/wikit-tokens-3.0.0-alpha.9.tgz",
+			"integrity": "sha512-SIVOvgKAw1kDChNOn3lrdF/DGXAzX4k90L6nquATbpJJlgOWbTeLdJ6gpQLb1HG/n47UjXDFsUs6oqRywAdj6w=="
 		},
 		"@wmde/wikit-vue-components": {
-			"version": "3.0.0-alpha.8",
-			"resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.8.tgz",
-			"integrity": "sha512-78PUZQzlxnzLZVo0qWDq9f3U1X2Q3GY7CpMvEff8ipx97fWXOaXYekIfhliJJrdka1Yz6gIIPxFwlmaqstNx8g==",
+			"version": "3.0.0-alpha.9",
+			"resolved": "https://registry.npmjs.org/@wmde/wikit-vue-components/-/wikit-vue-components-3.0.0-alpha.9.tgz",
+			"integrity": "sha512-3rUZjg0v+IBEX2uSbYcPACcTn3fHlnvuYxqNdJMqT2/E4lw/id/nZgTdRSZiLFCLj/isNzmcWYWl9x7cpM/mfA==",
 			"requires": {
-				"@wmde/wikit-tokens": "^3.0.0-alpha.8",
+				"@wmde/wikit-tokens": "^3.0.0-alpha.9",
 				"core-js": "^3.7.0",
 				"lodash.debounce": "^4.0.8",
 				"lodash.isequal": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
 	},
 	"dependencies": {
 		"@wmde/wikibase-datamodel-types": "^0.2.0",
-		"@wmde/wikit-tokens": "^3.0.0-alpha.8",
-		"@wmde/wikit-vue-components": "^3.0.0-alpha.8",
+		"@wmde/wikit-tokens": "^3.0.0-alpha.9",
+		"@wmde/wikit-vue-components": "^3.0.0-alpha.9",
 		"jest-environment-jsdom": "^29.2.2",
 		"vue": "^3.2.38",
 		"vuex": "^4.0.2"

--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -57,6 +57,7 @@ export default {
 
 <template>
 	<div class="wbl-snl-language-lookup">
+		<!-- eslint-disable-next-line vuejs-accessibility/tabindex-no-positive -->
 		<item-lookup
 			:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-language' )"
 			:placeholder="messages.getUnescaped(
@@ -68,6 +69,7 @@ export default {
 			:search-for-items="searchForItems"
 			:error="error"
 			:aria-required="true"
+			tabindex="1"
 			@update:model-value="$emit( 'update:modelValue', $event )"
 			@update:search-input="$emit( 'update:searchInput', $event )"
 		>

--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -51,6 +51,7 @@ export default {
 </script>
 
 <template>
+	<!-- eslint-disable-next-line vuejs-accessibility/tabindex-no-positive -->
 	<text-input
 		class="wbl-snl-lemma-input"
 		:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-lemma' )"
@@ -60,6 +61,7 @@ export default {
 		)"
 		name="lemma"
 		aria-required="true"
+		tabindex="1"
 		:error="error"
 		:value="modelValue"
 		@input="$emit( 'update:modelValue', $event )"

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -50,6 +50,7 @@ export default {
 
 <template>
 	<div class="wbl-snl-lexical-category-lookup">
+		<!-- eslint-disable-next-line vuejs-accessibility/tabindex-no-positive -->
 		<item-lookup
 			:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-lexicalcategory' )"
 			:placeholder="messages.getUnescaped(
@@ -62,6 +63,7 @@ export default {
 			:item-suggestions="lexicalCategorySuggestions"
 			:error="error"
 			:aria-required="true"
+			tabindex="1"
 			@update:model-value="$emit( 'update:modelValue', $event )"
 			@update:search-input="$emit( 'update:searchInput', $event )"
 		>

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -4,6 +4,7 @@ import { CREATE_LEXEME, HANDLE_LANGUAGE_CHANGE } from '@/store/actions';
 import {
 	computed,
 	ref,
+	onMounted,
 } from 'vue';
 import { useStore } from 'vuex';
 import { Button as WikitButton } from '@wmde/wikit-vue-components';
@@ -141,6 +142,13 @@ const onSubmit = async () => {
 	submitting.value = false;
 };
 
+onMounted( () => {
+	const linkNodes = document.querySelectorAll( '#wbl-snl-copyright a' );
+	linkNodes.forEach( ( linkNode ) => {
+		linkNode.setAttribute( 'tabindex', '3' );
+	} );
+} );
+
 </script>
 
 <script lang="ts">
@@ -176,12 +184,14 @@ export default {
 			<span v-html="error" />
 		</error-message>
 		<div>
+			<!-- eslint-disable-next-line vuejs-accessibility/tabindex-no-positive -->
 			<wikit-button
 				class="form-button-submit"
 				type="progressive"
 				variant="primary"
 				native-type="submit"
 				:disabled="submitting"
+				tabindex="2"
 			>
 				{{ submitButtonText }}
 			</wikit-button>

--- a/src/components/SearchExisting.vue
+++ b/src/components/SearchExisting.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import { useSearchLinker } from '@/plugins/SearchLinkerPlugin/SearchLinker';
-import { computed } from 'vue';
+import { computed, onMounted } from 'vue';
 import { useStore } from 'vuex';
 
 const messages = useMessages();
@@ -16,11 +16,22 @@ const searchMessage = computed( () => messages.get(
 	searchUrl.value,
 ) );
 
+onMounted( () => {
+	const linkNodes = document.querySelectorAll( '#wbl-snl-search-existing a' );
+	linkNodes.forEach( ( linkNode ) => {
+		linkNode.setAttribute( 'tabindex', '1' );
+	} );
+} );
+
 </script>
 
 <template>
 	<!-- eslint-disable-next-line vue/no-v-html -->
-	<p class="wbl-snl-search-existing" v-html="searchMessage" />
+	<p
+		id="wbl-snl-search-existing"
+		class="wbl-snl-search-existing"
+		v-html="searchMessage"
+	/>
 </template>
 
 <style lang="scss" scoped>

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -99,6 +99,7 @@ export default {
 </script>
 
 <template>
+	<!-- eslint-disable-next-line vuejs-accessibility/tabindex-no-positive -->
 	<wikit-lookup
 		class="wbl-snl-spelling-variant-lookup"
 		:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-lemma-language' )"
@@ -111,6 +112,7 @@ export default {
 		:value="selectedOption"
 		:error="error"
 		:aria-required="true"
+		tabindex="1"
 		@update:search-input="onSearchInput"
 		@input="onOptionSelected"
 	>
@@ -120,7 +122,14 @@ export default {
 		<template #suffix>
 			<required-asterisk />
 			<span class="wbl-snl-spelling-variant-lookup__help-link">
-				<wikit-link :href="helpUrl" target="_blank">{{ helpLinkText }}</wikit-link>
+				<!-- eslint-disable-next-line vuejs-accessibility/tabindex-no-positive -->
+				<wikit-link
+					:href="helpUrl"
+					tabindex="1"
+					target="_blank"
+				>
+					{{ helpLinkText }}
+				</wikit-link>
 			</span>
 		</template>
 	</wikit-lookup>


### PR DESCRIPTION
This is done with the main intention of effectively skipping the "terms of use" and "license" links when tabbing from the inputs to the create button, without making those links wholly inaccessible by tabbing.

TODO:
- [x] This needs a new pre-release of wikit first, see: wmde/wikit#644
- [x] sync with UX which version to prefer and why, the alternative is #329 

Bug: T322686