### PR TITLE
Add title message to the required asterisk to make it more legible

### DIFF
--- a/src/components/RequiredAsterisk.vue
+++ b/src/components/RequiredAsterisk.vue
@@ -1,3 +1,9 @@
+<script setup lang="ts">
+import { useMessages } from '@/plugins/MessagesPlugin/Messages';
+
+const messages = useMessages();
+</script>
+
 <script lang="ts">
 export default {
 	compatConfig: {
@@ -10,6 +16,7 @@ export default {
 	<span
 		class="wbl-snl-required-asterisk"
 		aria-hidden="true"
+		:title="messages.getUnescaped( 'wikibaselexeme-form-field-required' )"
 	>*</span>
 </template>
 

--- a/src/plugins/MessagesPlugin/DevMessagesRepository.ts
+++ b/src/plugins/MessagesPlugin/DevMessagesRepository.ts
@@ -30,6 +30,7 @@ const messages: Record<MessageKeys, string> = {
 	'wikibase-entityselector-notfound': 'No match was found',
 	'wikibase-shortcopyrightwarning': 'By clicking "$1", you agree to the <a href="./$2">terms of use</a>, and you irrevocably agree to release your contribution under the <a href="$3">$4</a>.',
 	copyrightpage: 'Project:Copyrights',
+	'wikibaselexeme-form-field-required': 'This field is required',
 };
 
 /** Messages repository for the dev entry point. */

--- a/src/plugins/MessagesPlugin/MessageKeys.ts
+++ b/src/plugins/MessagesPlugin/MessageKeys.ts
@@ -26,6 +26,7 @@ type MessageKeys
  | 'wikibase-lexeme-lemma-language-option'
  | 'wikibase-entityselector-notfound'
  | 'wikibase-shortcopyrightwarning'
- | 'copyrightpage';
+ | 'copyrightpage'
+ | 'wikibaselexeme-form-field-required';
 
 export default MessageKeys;


### PR DESCRIPTION
~~This reuses the respective core message for consistency.~~ The core message is not reused, because it is for validation not indicators.

Bug: T322683