### PR TITLE
Do not synthesize italic font in ToS&License copy

### DIFF
--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -210,7 +210,8 @@ export default {
 
 .wbl-snl-copyright {
 	@include small-text;
-
+        font-style: italic;
+        font-synthesis: none;
 	font-size: 0.8125rem;
 	margin-bottom: 0;
 }

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -210,9 +210,10 @@ export default {
 
 .wbl-snl-copyright {
 	@include small-text;
-        font-style: italic;
-        font-synthesis: none;
+
 	font-size: 0.8125rem;
+	font-style: italic;
+	font-synthesis: none;
 	margin-bottom: 0;
 }
 

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -212,7 +212,6 @@ export default {
 	@include small-text;
 
 	font-size: 0.8125rem;
-	font-style: italic;
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
This PR removes the italic styling from the license string because it makes it unreadable in non-Latin scripts. If the characters and font do not include italic variants, broken glyphs get rendered, which are particularly difficult to read in cursive scripts like those with Perso-Arabic alphabets. It is especially not a good idea here because the purpose of the NewLexeme page is explicitly multi-lingual.

In some contexts it may make sense to have language specific styles for emphasising text. However, this same string is not italicised elsewhere on Wikidata including the new item page so it is more consistent to not use an emphasised style here.