### PR TITLE
Address remaining npm related pending updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ The following dependencies should be ignored:
   in production, we use the versions shipped by MediaWiki core,
   so we should use the same versions for testing.
   The current versions shipped by MediaWiki core are listed in [foreign-resources.yaml](https://gerrit.wikimedia.org/g/mediawiki/core/+/master/resources/lib/foreign-resources.yaml).
+- Typescript:
+  Vue up until version 3.2.38 (which we currently use) [doesn't support typescript 4.8+](https://github.com/vuejs/core/issues/6554).
 - Vite 3:
   WMF CI is using Node 14.17, but Vite 3 requires Node 14.18 or higher. The upgrade of WMF CI is tracked in [T314470](https://phabricator.wikimedia.org/T314470), the update of Vite itself in [T314468](https://phabricator.wikimedia.org/T314468).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"@vue/vue3-jest": "^29.2.2",
 				"@wmde/eslint-config-wikimedia-typescript": "^0.2.4",
 				"axe-core": "^4.5.2",
-				"cypress": "^11.2.0",
+				"cypress": "^12.3.0",
 				"cypress-axe": "^1.2.0",
 				"eslint": "^8.31.0",
 				"eslint-config-wikimedia": "^0.23.0",
@@ -51,7 +51,7 @@
 				"ts-jest": "^29.0.3",
 				"typescript": "~4.7.0",
 				"vite": "^2.9.15",
-				"vite-plugin-banner": "^0.6.1",
+				"vite-plugin-banner": "^0.7.0",
 				"vue-tsc": "^1.0.24"
 			},
 			"engines": {
@@ -3772,9 +3772,9 @@
 			"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
 		},
 		"node_modules/cypress": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-			"integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+			"integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -3825,7 +3825,7 @@
 				"cypress": "bin/cypress"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": "^14.0.0 || ^16.0.0 || >=18.0.0"
 			}
 		},
 		"node_modules/cypress-axe": {
@@ -9122,9 +9122,9 @@
 			"dev": true
 		},
 		"node_modules/json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
@@ -12926,9 +12926,9 @@
 			}
 		},
 		"node_modules/vite-plugin-banner": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/vite-plugin-banner/-/vite-plugin-banner-0.6.1.tgz",
-			"integrity": "sha512-E5abFbnqO21R1dCFwoRYAIcJArX3XAMZv1zV4uU9PcWQNt1PaWtj5SP1QcnbyXn2FhWSnvPkJp7yP16DeA/BzA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/vite-plugin-banner/-/vite-plugin-banner-0.7.0.tgz",
+			"integrity": "sha512-g0cm0wbrR6b6wR8FWtfD1RSDPacdumKEOAnneXv+NpJ9ez+j6rklRv6lMOO+aPf+Y6Zb8OzgIk0FXBZ6h+DeZQ==",
 			"dev": true
 		},
 		"node_modules/vue": {
@@ -16265,9 +16265,9 @@
 			"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
 		},
 		"cypress": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
-			"integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
+			"version": "12.3.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-12.3.0.tgz",
+			"integrity": "sha512-ZQNebibi6NBt51TRxRMYKeFvIiQZ01t50HSy7z/JMgRVqBUey3cdjog5MYEbzG6Ktti5ckDt1tfcC47lmFwXkw==",
 			"dev": true,
 			"requires": {
 				"@cypress/request": "^2.88.10",
@@ -20063,9 +20063,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true
 		},
 		"jsonfile": {
@@ -22856,9 +22856,9 @@
 			}
 		},
 		"vite-plugin-banner": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/vite-plugin-banner/-/vite-plugin-banner-0.6.1.tgz",
-			"integrity": "sha512-E5abFbnqO21R1dCFwoRYAIcJArX3XAMZv1zV4uU9PcWQNt1PaWtj5SP1QcnbyXn2FhWSnvPkJp7yP16DeA/BzA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/vite-plugin-banner/-/vite-plugin-banner-0.7.0.tgz",
+			"integrity": "sha512-g0cm0wbrR6b6wR8FWtfD1RSDPacdumKEOAnneXv+NpJ9ez+j6rklRv6lMOO+aPf+Y6Zb8OzgIk0FXBZ6h+DeZQ==",
 			"dev": true
 		},
 		"vue": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
 		"@vue/vue3-jest": "^29.2.2",
 		"@wmde/eslint-config-wikimedia-typescript": "^0.2.4",
 		"axe-core": "^4.5.2",
-		"cypress": "^11.2.0",
+		"cypress": "^12.3.0",
 		"cypress-axe": "^1.2.0",
 		"eslint": "^8.31.0",
 		"eslint-config-wikimedia": "^0.23.0",
@@ -85,7 +85,7 @@
 		"ts-jest": "^29.0.3",
 		"typescript": "~4.7.0",
 		"vite": "^2.9.15",
-		"vite-plugin-banner": "^0.6.1",
+		"vite-plugin-banner": "^0.7.0",
 		"vue-tsc": "^1.0.24"
 	},
 	"lint-staged": {


### PR DESCRIPTION
This addresses the remaining npm related dependabot PRs

Updates vite-plugin-banner, json5 and cypress and explains why we can't update typescript for now.

Bug: T326199