### PR TITLE
Update Eslint dependencies 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"axe-core": "^4.7.1",
 				"cypress": "^12.13.0",
 				"cypress-axe": "^1.4.0",
-				"eslint": "^8.36.0",
+				"eslint": "^8.41.0",
 				"eslint-config-wikimedia": "^0.24.0",
 				"eslint-plugin-cypress": "^2.13.3",
 				"eslint-plugin-vue": "^9.14.0",
@@ -725,14 +725,14 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
-			"integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+			"integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.5.0",
+				"espree": "^9.5.2",
 				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -793,9 +793,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
-			"integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
+			"version": "8.41.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
+			"integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4992,15 +4992,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
-			"integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
+			"version": "8.41.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
+			"integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.4.0",
-				"@eslint/eslintrc": "^2.0.1",
-				"@eslint/js": "8.36.0",
+				"@eslint/eslintrc": "^2.0.3",
+				"@eslint/js": "8.41.0",
 				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -5010,9 +5010,9 @@
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.1.1",
-				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.5.0",
+				"eslint-scope": "^7.2.0",
+				"eslint-visitor-keys": "^3.4.1",
+				"espree": "^9.5.2",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -5020,13 +5020,12 @@
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
 				"globals": "^13.19.0",
-				"grapheme-splitter": "^1.0.4",
+				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
-				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
@@ -5727,12 +5726,15 @@
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint/node_modules/ansi-styles": {
@@ -5803,9 +5805,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-			"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+			"integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
 			"dev": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
@@ -5813,6 +5815,9 @@
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/eslint/node_modules/estraverse": {
@@ -5946,14 +5951,14 @@
 			}
 		},
 		"node_modules/espree": {
-			"version": "9.5.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
-			"integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
+			"version": "9.5.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+			"integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
 			"dev": true,
 			"dependencies": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -6647,6 +6652,12 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+			"dev": true
+		},
+		"node_modules/graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
 		},
 		"node_modules/hard-rejection": {
@@ -9123,12 +9134,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/js-sdsl": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-			"integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-			"dev": true
 		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
@@ -14032,14 +14037,14 @@
 			"dev": true
 		},
 		"@eslint/eslintrc": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.1.tgz",
-			"integrity": "sha512-eFRmABvW2E5Ho6f5fHLqgena46rOj7r7OKHYfLElqcBfGFHHpjBhivyi5+jOEQuSpdc/1phIZJlbC2te+tZNIw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.0.3.tgz",
+			"integrity": "sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
-				"espree": "^9.5.0",
+				"espree": "^9.5.2",
 				"globals": "^13.19.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.2.1",
@@ -14081,9 +14086,9 @@
 			}
 		},
 		"@eslint/js": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.36.0.tgz",
-			"integrity": "sha512-lxJ9R5ygVm8ZWgYdUweoq5ownDlJ4upvoWmO4eLxBYHdMo+vZ/Rx0EN6MbKWDJOSUGrqJy2Gt+Dyv/VKml0fjg==",
+			"version": "8.41.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.41.0.tgz",
+			"integrity": "sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==",
 			"dev": true
 		},
 		"@hapi/hoek": {
@@ -17233,15 +17238,15 @@
 			}
 		},
 		"eslint": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
-			"integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
+			"version": "8.41.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.41.0.tgz",
+			"integrity": "sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.4.0",
-				"@eslint/eslintrc": "^2.0.1",
-				"@eslint/js": "8.36.0",
+				"@eslint/eslintrc": "^2.0.3",
+				"@eslint/js": "8.41.0",
 				"@humanwhocodes/config-array": "^0.11.8",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -17251,9 +17256,9 @@
 				"debug": "^4.3.2",
 				"doctrine": "^3.0.0",
 				"escape-string-regexp": "^4.0.0",
-				"eslint-scope": "^7.1.1",
-				"eslint-visitor-keys": "^3.3.0",
-				"espree": "^9.5.0",
+				"eslint-scope": "^7.2.0",
+				"eslint-visitor-keys": "^3.4.1",
+				"espree": "^9.5.2",
 				"esquery": "^1.4.2",
 				"esutils": "^2.0.2",
 				"fast-deep-equal": "^3.1.3",
@@ -17261,13 +17266,12 @@
 				"find-up": "^5.0.0",
 				"glob-parent": "^6.0.2",
 				"globals": "^13.19.0",
-				"grapheme-splitter": "^1.0.4",
+				"graphemer": "^1.4.0",
 				"ignore": "^5.2.0",
 				"import-fresh": "^3.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-glob": "^4.0.0",
 				"is-path-inside": "^3.0.3",
-				"js-sdsl": "^4.1.4",
 				"js-yaml": "^4.1.0",
 				"json-stable-stringify-without-jsonify": "^1.0.1",
 				"levn": "^0.4.1",
@@ -17327,9 +17331,9 @@
 					"dev": true
 				},
 				"eslint-scope": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
-					"integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
+					"integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
 					"dev": true,
 					"requires": {
 						"esrecurse": "^4.3.0",
@@ -17890,20 +17894,20 @@
 			}
 		},
 		"eslint-visitor-keys": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-			"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
+			"integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
 			"dev": true
 		},
 		"espree": {
-			"version": "9.5.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.0.tgz",
-			"integrity": "sha512-JPbJGhKc47++oo4JkEoTe2wjy4fmMwvFpgJT9cQzmfXKp22Dr6Hf1tdCteLz1h0P3t+mGvWZ+4Uankvh8+c6zw==",
+			"version": "9.5.2",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.5.2.tgz",
+			"integrity": "sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==",
 			"dev": true,
 			"requires": {
 				"acorn": "^8.8.0",
 				"acorn-jsx": "^5.3.2",
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.1"
 			}
 		},
 		"esprima": {
@@ -18425,6 +18429,12 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
+			"dev": true
+		},
+		"graphemer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
 		},
 		"hard-rejection": {
@@ -20202,12 +20212,6 @@
 					}
 				}
 			}
-		},
-		"js-sdsl": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-			"integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-			"dev": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 		"axe-core": "^4.7.1",
 		"cypress": "^12.13.0",
 		"cypress-axe": "^1.4.0",
-		"eslint": "^8.36.0",
+		"eslint": "^8.41.0",
 		"eslint-config-wikimedia": "^0.24.0",
 		"eslint-plugin-cypress": "^2.13.3",
 		"eslint-plugin-vue": "^9.14.0",

--- a/src/components/AnonymousEditWarning.vue
+++ b/src/components/AnonymousEditWarning.vue
@@ -8,12 +8,12 @@ const messages = useMessages();
 const warning = computed(
 	() => messages.get( 'wikibase-anonymouseditwarning' ) );
 const config = useConfig();
-
+const isAnonymous = config.isAnonymous;
 </script>
 
 <template>
 	<warning-message
-		v-if="config.isAnonymous"
+		v-if="isAnonymous"
 		class="wbl-snl-anonymous-edit-warning"
 	>
 		<!-- eslint-disable-next-line vue/no-v-html -->

--- a/src/components/ItemLookup.vue
+++ b/src/components/ItemLookup.vue
@@ -26,6 +26,11 @@ const props = withDefaults( defineProps<Props>(), {
 	ariaRequired: false,
 } );
 
+// todo
+const propsSearchInput = computed( () => {
+	return props.searchInput;
+} );
+
 const emit = defineEmits( {
 	'update:modelValue': ( value: Props['value'] ) => {
 		return value === null || /^Q\d+$/.test( value.id );
@@ -132,13 +137,16 @@ const onWikitOptionSelected = ( value: unknown ) => {
 };
 
 const messages = useMessages();
+const noResultsMessage = computed(
+	() => messages.getUnescaped( 'wikibase-entityselector-notfound' ) );
+
 </script>
 
 <template>
 	<wikit-lookup
 		:label="label"
 		:placeholder="placeholder"
-		:search-input="props.searchInput"
+		:search-input="propsSearchInput"
 		:menu-items="wikitMenuItems"
 		:value="wikitValue"
 		:error="error"
@@ -148,7 +156,7 @@ const messages = useMessages();
 		@input="onWikitOptionSelected"
 	>
 		<template #no-results>
-			{{ messages.getUnescaped( 'wikibase-entityselector-notfound' ) }}
+			{{ noResultsMessage }}
 		</template>
 		<template #suffix>
 			<slot name="suffix" />

--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -21,6 +21,12 @@ defineEmits<{
 }>();
 
 const messages = useMessages();
+const itemLookupLabelMessage = computed(
+	() => messages.getUnescaped( 'wikibaselexeme-newlexeme-language' ) );
+const itemLookupPlaceholderMessage = computed(
+	() => messages.getUnescaped(
+		'wikibaselexeme-newlexeme-language-placeholder-with-example',
+		config.placeholderExampleData.languageLabel ) );
 
 const searcher = useLanguageItemSearch();
 const searchForItems = searcher.searchItems.bind( searcher );
@@ -58,11 +64,8 @@ export default {
 <template>
 	<div class="wbl-snl-language-lookup">
 		<item-lookup
-			:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-language' )"
-			:placeholder="messages.getUnescaped(
-				'wikibaselexeme-newlexeme-language-placeholder-with-example',
-				config.placeholderExampleData.languageLabel
-			)"
+			:label="itemLookupLabelMessage"
+			:placeholder="itemLookupPlaceholderMessage"
 			:value="modelValue"
 			:search-input="searchInput"
 			:search-for-items="searchForItems"

--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -17,6 +17,12 @@ defineEmits<{
 }>();
 
 const messages = useMessages();
+const textInputLabelMessage = computed(
+	() => messages.getUnescaped( 'wikibaselexeme-newlexeme-lemma' ) );
+const textInputPlaceholderMessage = computed(
+	() => messages.getUnescaped(
+		'wikibaselexeme-newlexeme-lemma-placeholder-with-example',
+		exampleLemma ) );
 
 const config = useConfig();
 const exampleLemma = config.placeholderExampleData.lemma;
@@ -53,11 +59,8 @@ export default {
 <template>
 	<text-input
 		class="wbl-snl-lemma-input"
-		:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-lemma' )"
-		:placeholder="messages.getUnescaped(
-			'wikibaselexeme-newlexeme-lemma-placeholder-with-example',
-			exampleLemma
-		)"
+		:label="textInputLabelMessage"
+		:placeholder="textInputPlaceholderMessage"
 		name="lemma"
 		aria-required="true"
 		:error="error"

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -38,6 +38,13 @@ const error = computed( () => {
 		),
 	};
 } );
+
+const itemLookupLabelMessage = computed(
+	() => messages.getUnescaped( 'wikibaselexeme-newlexeme-lexicalcategory' ) );
+const itemLookupPlaceholderMessage = computed(
+	() => messages.getUnescaped(
+		'wikibaselexeme-newlexeme-lexicalcategory-placeholder-with-example',
+		exampleLexCategory ) );
 </script>
 
 <script lang="ts">
@@ -51,11 +58,8 @@ export default {
 <template>
 	<div class="wbl-snl-lexical-category-lookup">
 		<item-lookup
-			:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-lexicalcategory' )"
-			:placeholder="messages.getUnescaped(
-				'wikibaselexeme-newlexeme-lexicalcategory-placeholder-with-example',
-				exampleLexCategory
-			)"
+			:label="itemLookupLabelMessage"
+			:placeholder="itemLookupPlaceholderMessage"
 			:value="modelValue"
 			:search-input="searchInput"
 			:search-for-items="searchForItems"

--- a/src/components/RequiredAsterisk.vue
+++ b/src/components/RequiredAsterisk.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
+import { computed } from 'vue/dist/vue';
 
 const messages = useMessages();
+const fieldRequiredMessage = computed(
+	() => messages.getUnescaped( 'wikibaselexeme-form-field-required' ) );
 </script>
 
 <script lang="ts">
@@ -16,7 +19,7 @@ export default {
 	<span
 		class="wbl-snl-required-asterisk"
 		aria-hidden="true"
-		:title="messages.getUnescaped( 'wikibaselexeme-form-field-required' )"
+		:title="fieldRequiredMessage"
 	>*</span>
 </template>
 

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -27,6 +27,16 @@ const props = withDefaults( defineProps<Props>(), {
 const languageCodesProvider = useLanguageCodesProvider();
 const messages = useMessages();
 
+const wikitLookupLabelMessage = computed(
+	() => messages.get( 'wikibaselexeme-newlexeme-lemma-language' ) );
+const wikitLookupPlaceholderMessage = computed(
+	() => messages.getUnescaped(
+		'wikibaselexeme-newlexeme-lemma-language-placeholder-with-example',
+		config.placeholderExampleData.spellingVariant,
+	) );
+const noResultsMessage = computed(
+	() => messages.getUnescaped( 'wikibase-entityselector-notfound' ) );
+
 const wbLexemeTermLanguages: WikitMenuItem[] = [];
 languageCodesProvider.getLanguages().forEach(
 	( name, code ) => {
@@ -101,11 +111,8 @@ export default {
 <template>
 	<wikit-lookup
 		class="wbl-snl-spelling-variant-lookup"
-		:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-lemma-language' )"
-		:placeholder="messages.getUnescaped(
-			'wikibaselexeme-newlexeme-lemma-language-placeholder-with-example',
-			config.placeholderExampleData.spellingVariant
-		)"
+		:label="wikitLookupLabelMessage"
+		:placeholder="wikitLookupPlaceholderMessage"
 		:search-input="searchInput"
 		:menu-items="menuItems"
 		:value="selectedOption"
@@ -115,7 +122,7 @@ export default {
 		@input="onOptionSelected"
 	>
 		<template #no-results>
-			{{ messages.getUnescaped( 'wikibase-entityselector-notfound' ) }}
+			{{ noResultsMessage }}
 		</template>
 		<template #suffix>
 			<required-asterisk />


### PR DESCRIPTION
Since the new Eslint 3.37 and further version `property` dot should be on the same line what impossible in `<template>`.
Example:
`:label="messages.getUnescaped( 'wikibaselexeme-newlexeme-language' )"`
 :arrow_down_small: 
`:label="messages`
`.getUnescaped( 'wikibaselexeme-newlexeme-language' )"`

Solutions:
1. Possibly, it's Eslint bug and we should create a bug report;
2. Refactor our code. 