### PR TITLE
Add permissions to workflow yaml

### DIFF
--- a/.github/workflows/comment-deploy-url-to-pr.yaml
+++ b/.github/workflows/comment-deploy-url-to-pr.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
     comment-on-pr:
         runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+
         name: Comment deploy URL to PR
         steps:
             - name: Get branch hash


### PR DESCRIPTION
This ocurred due to changes in the package `thollander/actions-comment-pull-request` starting v2.3.1. 
see https://github.com/thollander/actions-comment-pull-request/issues/181 for further details