### PR TITLE
Improve the required marker for fields

### DIFF
--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -77,3 +77,14 @@ export default {
 		</item-lookup>
 	</div>
 </template>
+
+<style lang="scss">
+@import "@wmde/wikit-tokens/variables";
+
+/* stylelint-disable plugin/stylelint-bem-namics, selector-class-pattern */
+.wbl-snl-language-lookup .wikit .wikit-Lookup__label-wrapper {
+	gap: $dimension-spacing-xsmall;
+}
+/* stylelint-enable plugin/stylelint-bem-namics, selector-class-pattern */
+
+</style>

--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -69,3 +69,13 @@ export default {
 		</template>
 	</text-input>
 </template>
+
+<style lang="scss">
+@import "@wmde/wikit-tokens/variables";
+
+/* stylelint-disable plugin/stylelint-bem-namics, selector-class-pattern */
+.wbl-snl-lemma-input.wikit .wikit-TextInput__label-wrapper {
+	gap: $dimension-spacing-xsmall;
+}
+/* stylelint-enable plugin/stylelint-bem-namics, selector-class-pattern */
+</style>

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -71,3 +71,13 @@ export default {
 		</item-lookup>
 	</div>
 </template>
+
+<style lang="scss">
+@import "@wmde/wikit-tokens/variables";
+/* stylelint-disable plugin/stylelint-bem-namics, selector-class-pattern */
+.wbl-snl-lexical-category-lookup .wikit .wikit-Lookup__label-wrapper {
+	gap: $dimension-spacing-xsmall;
+}
+/* stylelint-enable plugin/stylelint-bem-namics, selector-class-pattern */
+
+</style>

--- a/src/components/RequiredAsterisk.vue
+++ b/src/components/RequiredAsterisk.vue
@@ -24,6 +24,9 @@ export default {
 @import "@wmde/wikit-tokens/variables";
 
 .wbl-snl-required-asterisk {
+	font-size: $font-size-xxlarge;
+	line-height: 0;
+
 	&:not(:first-child) {
 		margin-inline-start: $dimension-spacing-small;
 	}

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -126,10 +126,16 @@ export default {
 	</wikit-lookup>
 </template>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @import "@wmde/wikit-tokens/variables";
 
 .wbl-snl-spelling-variant-lookup {
+	/* stylelint-disable plugin/stylelint-bem-namics, selector-class-pattern */
+	&.wikit .wikit-Lookup__label-wrapper {
+		gap: $dimension-spacing-xsmall;
+	}
+	/* stylelint-enable plugin/stylelint-bem-namics, selector-class-pattern */
+
 	&__help-link {
 		padding-bottom: $wikit-Label-padding-block-end;
 		display: inline-block;


### PR DESCRIPTION
This moves the required marker closer to the actual label to make the connection more obvious. Also it makes it bigger.

The style blocks for overriding the gaps must not be scoped, because it otherwise the styles do not match anything.

The `line-height: 0;` has been added because otherwise the size of the asterisk affects the whole label and thus also the overall layout.

Bug: T322683