### PR TITLE
Revert "Mostly downgrade required Node version from 16 to 14"

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -10,12 +10,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: "14"
-
-            - name: Setup NPM
-              run: npm install -g npm@8
-              # Node 14 (above) comes with NPM v6,
-              # which does not install peer dependencies that we need
+                  node-version: "16"
 
             - name: Install Dependencies
               run: npm ci

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Please report bugs on [phabricator](https://phabricator.wikimedia.org/project/vi
 
 ## Local Development
 
-_**Prerequisites: This repository requires node v14+ and npm v7+**_
+_**Prerequisites: This repository requires node v16 and up**_
 
 ### Initial setup
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	},
 	"homepage": "https://github.com/wmde/new-lexeme-special-page#readme",
 	"engines": {
-		"node": ">=14"
+		"node": ">=16"
 	},
 	"dependencies": {
 		"@wmde/wikibase-datamodel-types": "^0.2.0",


### PR DESCRIPTION
The motivation at the time was apparently that [Fresh][1] only supported up to Node 14, but nowadays it supports up to 20, and 18 is the default. Meanwhile, some CI errors on #519 indicate that dependencies such as @vue/language-core are starting to require syntax like `??=` that’s not available in Node 14. Let’s bump the Node requirement to 16, the version we use in WikibaseLexeme CI.

This reverts commit db8ae7d515916b391d4624b2d5de0b60b14f7d54 (#151).

[1]: https://github.com/wikimedia/fresh

Bug: T348108