### PR TITLE
Simplify createComponent() types in tests

### DIFF
--- a/tests/unit/components/LemmaInput.test.ts
+++ b/tests/unit/components/LemmaInput.test.ts
@@ -2,7 +2,6 @@ import { MessagesKey } from '@/plugins/MessagesPlugin/Messages';
 import {
 	DOMWrapper,
 	mount,
-	MountingOptions,
 } from '@vue/test-utils';
 import LemmaInput from '@/components/LemmaInput.vue';
 import { ConfigKey } from '@/plugins/ConfigPlugin/Config';
@@ -19,8 +18,15 @@ describe( 'LemmaInput', () => {
 
 	let store: Store<RootState>;
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	function createComponent( config: Partial<MountingOptions<any>> = {} ) {
+	function createComponent( config: {
+		props?: {
+			modelValue?: string;
+		};
+		global?: {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			provide?: Record<symbol, any>;
+		};
+	} = {} ) {
 		store = initStore( {
 			lexemeCreator: unusedLexemeCreator,
 			langCodeRetriever: unusedLangCodeRetriever,
@@ -29,7 +35,6 @@ describe( 'LemmaInput', () => {
 		} );
 
 		return mount( LemmaInput, {
-			...config,
 			props: {
 				modelValue: '',
 				...config.props,


### PR DESCRIPTION
The `...config` in particular was causing type issues when upgrading @vue/test-utils in #492; and while that pull request is also blocked for other reasons, I think we can make our lives easier by simplifying these types. Callers of this method (which is local to this one test file) only pass in `props` and/or `global.provide`, so we can just specify the types for those members instead of full `ComponentOptions`; the `Props` type from `LemmaInput` is just duplicated, since I think that’s simpler than trying to get it back out of the full/exported `LemmaInput` type again.

Bug: T348108