### PR TITLE
Update stylelint-related packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"vuex": "^4.0.2"
 			},
 			"devDependencies": {
-				"@namics/stylelint-bem": "^8.1.0",
+				"@namics/stylelint-bem": "^9.0.0",
 				"@rushstack/eslint-patch": "^1.3.2",
 				"@types/jest": "^29.5.5",
 				"@types/lodash": "^4.14.199",
@@ -44,10 +44,10 @@
 				"prettier": "^2.8.8",
 				"sass": "^1.69.0",
 				"start-server-and-test": "^2.0.0",
-				"stylelint": "^14.16.1",
+				"stylelint": "^15.10.3",
 				"stylelint-config-recommended-vue": "^1.5.0",
-				"stylelint-config-standard-scss": "^6.1.0",
-				"stylelint-config-wikimedia": "^0.15.0",
+				"stylelint-config-standard-scss": "^11.0.0",
+				"stylelint-config-wikimedia": "^0.16.1",
 				"ts-jest": "^29.1.1",
 				"typescript": "~4.7.0",
 				"vite": "^3.2.7",
@@ -589,21 +589,90 @@
 				"node": ">=0.1.90"
 			}
 		},
-		"node_modules/@csstools/selector-specificity": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
-			"integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.2.tgz",
+			"integrity": "sha512-sLYGdAdEY2x7TSw9FtmdaTrh2wFtRJO5VMbBrA8tEqEod7GEggFmxTSK9XqExib3yMuYNcvcTdCZIP6ukdjAIA==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
 			"engines": {
-				"node": "^12 || ^14 || >=16"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/csstools"
+				"node": "^14 || ^16 || >=18"
 			},
 			"peerDependencies": {
-				"postcss": "^8.2",
-				"postcss-selector-parser": "^6.0.10"
+				"@csstools/css-tokenizer": "^2.2.1"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.1.tgz",
+			"integrity": "sha512-Zmsf2f/CaEPWEVgw29odOj+WEVoiJy9s9NOv5GgNY9mZ1CZ7394By6wONrONrTsnNDv6F9hR02nvFihrGVGHBg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			}
+		},
+		"node_modules/@csstools/media-query-list-parser": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.5.tgz",
+			"integrity": "sha512-IxVBdYzR8pYe89JiyXQuYk4aVVoCPhMJkz6ElRwlVysjwURTsTk/bmY/z4FfeRE+CRBMlykPwXEVUg8lThv7AQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^2.3.2",
+				"@csstools/css-tokenizer": "^2.2.1"
+			}
+		},
+		"node_modules/@csstools/selector-specificity": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz",
+			"integrity": "sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^6.0.13"
 			}
 		},
 		"node_modules/@cypress/request": {
@@ -1583,16 +1652,16 @@
 			"dev": true
 		},
 		"node_modules/@namics/stylelint-bem": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@namics/stylelint-bem/-/stylelint-bem-8.1.0.tgz",
-			"integrity": "sha512-lVK6mqAD1WjKwtXW4pZ/V7T3TM3WFG+aqYtAxqYLp7et3Rm5Tu3JoXYhA63HE4t467XOJTK+K2foIzYz42j69w==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@namics/stylelint-bem/-/stylelint-bem-9.0.0.tgz",
+			"integrity": "sha512-fjEykSt5jZYo4wy4dFwqvxNz0a5yyvZa/rxpLM0kxv8y8cKKB3kBCi8XM1okMz9wHeIIg+M4vLZVg7CrlKyQdQ==",
 			"dev": true,
 			"dependencies": {
-				"css-selector-classes": "0.1.2",
+				"css-selector-parser": "2.3.2",
 				"postcss-resolve-nested-selector": "0.1.1"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=16"
 			},
 			"peerDependencies": {
 				"stylelint": ">=7.0.0 <16.0.0"
@@ -1799,9 +1868,9 @@
 			"dev": true
 		},
 		"node_modules/@types/minimist": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.3.tgz",
+			"integrity": "sha512-ZYFzrvyWUNhaPomn80dsMNgMeXxNWZBdkuG/hWlUvXvbdUH8ZERNBGXnU87McuGcWDsyzX2aChCv/SVN348k3A==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
@@ -1813,12 +1882,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-			"dev": true
-		},
-		"node_modules/@types/parse-json": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
 		"node_modules/@types/semver": {
@@ -2733,15 +2796,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/array-uniq": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -3266,17 +3320,42 @@
 			}
 		},
 		"node_modules/camelcase-keys": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-			"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
+			"integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
 			"dev": true,
 			"dependencies": {
-				"camelcase": "^5.3.1",
-				"map-obj": "^4.0.0",
-				"quick-lru": "^4.0.1"
+				"camelcase": "^6.3.0",
+				"map-obj": "^4.1.0",
+				"quick-lru": "^5.1.1",
+				"type-fest": "^1.2.1"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/camelcase-keys/node_modules/camelcase": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/camelcase-keys/node_modules/type-fest": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -3636,31 +3715,6 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
 		},
-		"node_modules/cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-			"dev": true,
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/cosmiconfig/node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"dev": true,
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/create-jest": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -3767,9 +3821,9 @@
 			}
 		},
 		"node_modules/css-functions-list": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
-			"integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.0.tgz",
+			"integrity": "sha512-d/jBMPyYybkkLVypgtGv12R+pIFw4/f/IHtCTxWpZc8ofTYOPigIgmA6vu5rMHartZC+WuXhBUHfnyNUIQSYrg==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.22"
@@ -3812,26 +3866,20 @@
 				"xtend": ">=4.0.0 <4.1.0-0"
 			}
 		},
-		"node_modules/css-selector-classes": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/css-selector-classes/-/css-selector-classes-0.1.2.tgz",
-			"integrity": "sha512-I9BqkJUoQgd//YQfRKpk+ohVJBa1TnJjcbHGNdAy8mfrzUMpTkFDEIMQNkn8hiV1soBFGqBQcxJRoh81XhAVYw==",
-			"dev": true,
-			"dependencies": {
-				"array-uniq": "^1.0.2",
-				"css-selector-parser": "~1.0.3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/css-selector-parser": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.0.4.tgz",
-			"integrity": "sha512-hu4/RJPZaghwTY/B7PpCt2s1Vq8qzT4UYhi279u4MB8TADfbpR3V3M9m4AnUVleQsrVkPqe/dGLbzxi4GgTg2A==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-2.3.2.tgz",
+			"integrity": "sha512-JjnG6/pdLJh3iqipq7kteNVtbIczsU2A1cNxb+VAiniSuNmrB/NI3us4rSCfArvlwRXYly+jZhUUfEoInSH9Qg==",
 			"dev": true,
-			"engines": [
-				"node >= 0.4.0"
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/mdevils"
+				},
+				{
+					"type": "patreon",
+					"url": "https://patreon.com/mdevils"
+				}
 			]
 		},
 		"node_modules/css-tokenize": {
@@ -3845,17 +3893,16 @@
 			}
 		},
 		"node_modules/css-tree": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.1.0.tgz",
-			"integrity": "sha512-PcysZRzToBbrpoUrZ9qfblRIRf8zbEAkU0AIpQFtgkFK0vSbzOmBCvdSAx2Zg7Xx5wiYJKUKk0NMP7kxevie/A==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
 			"dev": true,
 			"dependencies": {
-				"mdn-data": "2.0.27",
+				"mdn-data": "2.0.30",
 				"source-map-js": "^1.0.1"
 			},
 			"engines": {
-				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-				"npm": ">=7.0.0"
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
 		},
 		"node_modules/cssesc": {
@@ -4121,23 +4168,38 @@
 			}
 		},
 		"node_modules/decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
 			"dev": true,
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/decamelize-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
 			"dev": true,
 			"dependencies": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
 			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/decamelize-keys/node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6192,9 +6254,9 @@
 			"dev": true
 		},
 		"node_modules/fast-glob": {
-			"version": "3.2.12",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
 			"dev": true,
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -6796,9 +6858,9 @@
 			"dev": true
 		},
 		"node_modules/html-tags": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
-			"integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
@@ -9431,9 +9493,9 @@
 			}
 		},
 		"node_modules/known-css-properties": {
-			"version": "0.26.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
-			"integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.28.0.tgz",
+			"integrity": "sha512-9pSL5XB4J+ifHP0e0jmmC98OGC1nL8/JjS+fi6mnTlIf//yt/MfVLtKg7S6nCtj/8KTcWX7nRlY0XywoYY1ISQ==",
 			"dev": true
 		},
 		"node_modules/lazy-ass": {
@@ -10254,9 +10316,9 @@
 			}
 		},
 		"node_modules/mdn-data": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.27.tgz",
-			"integrity": "sha512-kwqO0I0jtWr25KcfLm9pia8vLZ8qoAKhWZuZMbneJq3jjBD3gl5nZs8l8Tu3ZBlBAHVQtDur9rdDGyvtfVraHQ==",
+			"version": "2.0.30",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
 			"dev": true
 		},
 		"node_modules/memorystream": {
@@ -10269,23 +10331,39 @@
 			}
 		},
 		"node_modules/meow": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-			"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+			"version": "10.1.5",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
+			"integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
 			"dev": true,
 			"dependencies": {
-				"@types/minimist": "^1.2.0",
-				"camelcase-keys": "^6.2.2",
-				"decamelize": "^1.2.0",
+				"@types/minimist": "^1.2.2",
+				"camelcase-keys": "^7.0.0",
+				"decamelize": "^5.0.0",
 				"decamelize-keys": "^1.1.0",
 				"hard-rejection": "^2.1.0",
 				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.0",
-				"read-pkg-up": "^7.0.1",
-				"redent": "^3.0.0",
-				"trim-newlines": "^3.0.0",
-				"type-fest": "^0.18.0",
-				"yargs-parser": "^20.2.3"
+				"normalize-package-data": "^3.0.2",
+				"read-pkg-up": "^8.0.0",
+				"redent": "^4.0.0",
+				"trim-newlines": "^4.0.2",
+				"type-fest": "^1.2.2",
+				"yargs-parser": "^20.2.9"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=10"
@@ -10306,6 +10384,21 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/meow/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/meow/node_modules/normalize-package-data": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
@@ -10321,10 +10414,75 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/meow/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/read-pkg": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+			"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+			"dev": true,
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.0",
+				"normalize-package-data": "^3.0.2",
+				"parse-json": "^5.2.0",
+				"type-fest": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow/node_modules/read-pkg-up": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+			"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^5.0.0",
+				"read-pkg": "^6.0.0",
+				"type-fest": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/meow/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -10337,9 +10495,9 @@
 			}
 		},
 		"node_modules/meow/node_modules/type-fest": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-			"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
 			"dev": true,
 			"engines": {
 				"node": ">=10"
@@ -11105,9 +11263,9 @@
 			}
 		},
 		"node_modules/postcss-scss": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.5.tgz",
-			"integrity": "sha512-F7xpB6TrXyqUh3GKdyB4Gkp3QL3DDW1+uI+gxx/oJnUt/qXI4trj5OGlp9rOKdoABGULuqtqeG+3HEVQk4DjmA==",
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+			"integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
 			"dev": true,
 			"funding": [
 				{
@@ -11117,19 +11275,23 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/postcss-scss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"engines": {
 				"node": ">=12.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.3.3"
+				"postcss": "^8.4.29"
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.0.11",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-			"integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+			"version": "6.0.13",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+			"integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
 			"dev": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -11340,12 +11502,15 @@
 			]
 		},
 		"node_modules/quick-lru": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
 			"dev": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ramda": {
@@ -11469,16 +11634,46 @@
 			}
 		},
 		"node_modules/redent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
 			"dev": true,
 			"dependencies": {
-				"indent-string": "^4.0.0",
-				"strip-indent": "^3.0.0"
+				"indent-string": "^5.0.0",
+				"strip-indent": "^4.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/redent/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/redent/node_modules/strip-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+			"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+			"dev": true,
+			"dependencies": {
+				"min-indent": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/regexp-tree": {
@@ -12261,55 +12456,57 @@
 			"dev": true
 		},
 		"node_modules/stylelint": {
-			"version": "14.16.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
-			"integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
+			"version": "15.10.3",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.3.tgz",
+			"integrity": "sha512-aBQMMxYvFzJJwkmg+BUUg3YfPyeuCuKo2f+LOw7yYbU8AZMblibwzp9OV4srHVeQldxvSFdz0/Xu8blq2AesiA==",
 			"dev": true,
 			"dependencies": {
-				"@csstools/selector-specificity": "^2.0.2",
+				"@csstools/css-parser-algorithms": "^2.3.1",
+				"@csstools/css-tokenizer": "^2.2.0",
+				"@csstools/media-query-list-parser": "^2.1.4",
+				"@csstools/selector-specificity": "^3.0.0",
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
-				"cosmiconfig": "^7.1.0",
-				"css-functions-list": "^3.1.0",
+				"cosmiconfig": "^8.2.0",
+				"css-functions-list": "^3.2.0",
+				"css-tree": "^2.3.1",
 				"debug": "^4.3.4",
-				"fast-glob": "^3.2.12",
+				"fast-glob": "^3.3.1",
 				"fastest-levenshtein": "^1.0.16",
 				"file-entry-cache": "^6.0.1",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
-				"html-tags": "^3.2.0",
-				"ignore": "^5.2.1",
+				"html-tags": "^3.3.1",
+				"ignore": "^5.2.4",
 				"import-lazy": "^4.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.26.0",
+				"known-css-properties": "^0.28.0",
 				"mathml-tag-names": "^2.1.3",
-				"meow": "^9.0.0",
+				"meow": "^10.1.5",
 				"micromatch": "^4.0.5",
 				"normalize-path": "^3.0.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.4.19",
-				"postcss-media-query-parser": "^0.2.3",
+				"postcss": "^8.4.27",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.11",
+				"postcss-selector-parser": "^6.0.13",
 				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1",
 				"style-search": "^0.1.0",
-				"supports-hyperlinks": "^2.3.0",
+				"supports-hyperlinks": "^3.0.0",
 				"svg-tags": "^1.0.0",
 				"table": "^6.8.1",
-				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^4.0.2"
+				"write-file-atomic": "^5.0.1"
 			},
 			"bin": {
-				"stylelint": "bin/stylelint.js"
+				"stylelint": "bin/stylelint.mjs"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": "^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -12330,27 +12527,30 @@
 			}
 		},
 		"node_modules/stylelint-config-recommended": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
-			"integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
+			"integrity": "sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==",
 			"dev": true,
+			"engines": {
+				"node": "^14.13.1 || >=16.0.0"
+			},
 			"peerDependencies": {
-				"stylelint": "^14.10.0"
+				"stylelint": "^15.10.0"
 			}
 		},
 		"node_modules/stylelint-config-recommended-scss": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-8.0.0.tgz",
-			"integrity": "sha512-BxjxEzRaZoQb7Iinc3p92GS6zRdRAkIuEu2ZFLTxJK2e1AIcCb5B5MXY9KOXdGTnYFZ+KKx6R4Fv9zU6CtMYPQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-13.0.0.tgz",
+			"integrity": "sha512-7AmMIsHTsuwUQm7I+DD5BGeIgCvqYZ4BpeYJJpb1cUXQwrJAKjA+GBotFZgUEGP8lAM+wmd91ovzOi8xfAyWEw==",
 			"dev": true,
 			"dependencies": {
-				"postcss-scss": "^4.0.2",
-				"stylelint-config-recommended": "^9.0.0",
-				"stylelint-scss": "^4.0.0"
+				"postcss-scss": "^4.0.7",
+				"stylelint-config-recommended": "^13.0.0",
+				"stylelint-scss": "^5.1.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.3.3",
-				"stylelint": "^14.10.0"
+				"stylelint": "^15.10.0"
 			},
 			"peerDependenciesMeta": {
 				"postcss": {
@@ -12395,29 +12595,32 @@
 			}
 		},
 		"node_modules/stylelint-config-standard": {
-			"version": "29.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-29.0.0.tgz",
-			"integrity": "sha512-uy8tZLbfq6ZrXy4JKu3W+7lYLgRQBxYTUUB88vPgQ+ZzAxdrvcaSUW9hOMNLYBnwH+9Kkj19M2DHdZ4gKwI7tg==",
+			"version": "34.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz",
+			"integrity": "sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==",
 			"dev": true,
 			"dependencies": {
-				"stylelint-config-recommended": "^9.0.0"
+				"stylelint-config-recommended": "^13.0.0"
+			},
+			"engines": {
+				"node": "^14.13.1 || >=16.0.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^14.14.0"
+				"stylelint": "^15.10.0"
 			}
 		},
 		"node_modules/stylelint-config-standard-scss": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-6.1.0.tgz",
-			"integrity": "sha512-iZ2B5kQT2G3rUzx+437cEpdcnFOQkwnwqXuY8Z0QUwIHQVE8mnYChGAquyKFUKZRZ0pRnrciARlPaR1RBtPb0Q==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-11.0.0.tgz",
+			"integrity": "sha512-fGE79NBOLg09a9afqGH/guJulRULCaQWWv4cv1v2bMX92B+fGb0y56WqIguwvFcliPmmUXiAhKrrnXilIeXoHA==",
 			"dev": true,
 			"dependencies": {
-				"stylelint-config-recommended-scss": "^8.0.0",
-				"stylelint-config-standard": "^29.0.0"
+				"stylelint-config-recommended-scss": "^13.0.0",
+				"stylelint-config-standard": "^34.0.0"
 			},
 			"peerDependencies": {
 				"postcss": "^8.3.3",
-				"stylelint": "^14.14.0"
+				"stylelint": "^15.10.0"
 			},
 			"peerDependenciesMeta": {
 				"postcss": {
@@ -12426,27 +12629,182 @@
 			}
 		},
 		"node_modules/stylelint-config-wikimedia": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-wikimedia/-/stylelint-config-wikimedia-0.15.0.tgz",
-			"integrity": "sha512-8cQ1qGbvA6qwmH+sT2m2h/yha77z564WRhuXJTD9rQl+IhN5R8nTdu9QKSCikB/mTQ/xmldsvcmA2YsTavO3ig==",
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/stylelint-config-wikimedia/-/stylelint-config-wikimedia-0.16.1.tgz",
+			"integrity": "sha512-FDVUyDyCBap2o2HAeJqIobdVdSTur5HFX5FymoKrzfMIYWxIV/55lTpyL1PR71TfVMaroDXJrIftLFW9mXKFhQ==",
 			"dev": true,
 			"dependencies": {
 				"browserslist-config-wikimedia": "0.5.0",
 				"postcss-html": "1.5.0",
 				"postcss-less": "6.0.0",
-				"stylelint": "14.16.1",
-				"stylelint-config-recommended": "9.0.0",
-				"stylelint-no-unsupported-browser-features": "6.1.0"
+				"stylelint": "15.10.1",
+				"stylelint-config-recommended": "13.0.0",
+				"stylelint-no-unsupported-browser-features": "6.1.0",
+				"stylelint-stylistic": "0.4.3"
 			},
 			"peerDependencies": {
 				"postcss-less": "^6.0.0"
 			}
+		},
+		"node_modules/stylelint-config-wikimedia/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"node_modules/stylelint-config-wikimedia/node_modules/balanced-match": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+			"dev": true
 		},
 		"node_modules/stylelint-config-wikimedia/node_modules/browserslist-config-wikimedia": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/browserslist-config-wikimedia/-/browserslist-config-wikimedia-0.5.0.tgz",
 			"integrity": "sha512-t+tvSnTeVhVF2lNRxoAlE51/ZCfUs5SNNZUnWu2N8xXOGMPTMyKk5l4mayvDdm+5L8oqmnALU+TjnN2Z+ZTCTw==",
 			"dev": true
+		},
+		"node_modules/stylelint-config-wikimedia/node_modules/cosmiconfig": {
+			"version": "8.3.6",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+			"dev": true,
+			"dependencies": {
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0",
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/stylelint-config-wikimedia/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/stylelint-config-wikimedia/node_modules/known-css-properties": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
+			"integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==",
+			"dev": true
+		},
+		"node_modules/stylelint-config-wikimedia/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/stylelint-config-wikimedia/node_modules/stylelint": {
+			"version": "15.10.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.1.tgz",
+			"integrity": "sha512-CYkzYrCFfA/gnOR+u9kJ1PpzwG10WLVnoxHDuBA/JiwGqdM9+yx9+ou6SE/y9YHtfv1mcLo06fdadHTOx4gBZQ==",
+			"dev": true,
+			"dependencies": {
+				"@csstools/css-parser-algorithms": "^2.3.0",
+				"@csstools/css-tokenizer": "^2.1.1",
+				"@csstools/media-query-list-parser": "^2.1.2",
+				"@csstools/selector-specificity": "^3.0.0",
+				"balanced-match": "^2.0.0",
+				"colord": "^2.9.3",
+				"cosmiconfig": "^8.2.0",
+				"css-functions-list": "^3.1.0",
+				"css-tree": "^2.3.1",
+				"debug": "^4.3.4",
+				"fast-glob": "^3.3.0",
+				"fastest-levenshtein": "^1.0.16",
+				"file-entry-cache": "^6.0.1",
+				"global-modules": "^2.0.0",
+				"globby": "^11.1.0",
+				"globjoin": "^0.1.4",
+				"html-tags": "^3.3.1",
+				"ignore": "^5.2.4",
+				"import-lazy": "^4.0.0",
+				"imurmurhash": "^0.1.4",
+				"is-plain-object": "^5.0.0",
+				"known-css-properties": "^0.27.0",
+				"mathml-tag-names": "^2.1.3",
+				"meow": "^10.1.5",
+				"micromatch": "^4.0.5",
+				"normalize-path": "^3.0.0",
+				"picocolors": "^1.0.0",
+				"postcss": "^8.4.24",
+				"postcss-resolve-nested-selector": "^0.1.1",
+				"postcss-safe-parser": "^6.0.0",
+				"postcss-selector-parser": "^6.0.13",
+				"postcss-value-parser": "^4.2.0",
+				"resolve-from": "^5.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"style-search": "^0.1.0",
+				"supports-hyperlinks": "^3.0.0",
+				"svg-tags": "^1.0.0",
+				"table": "^6.8.1",
+				"write-file-atomic": "^5.0.1"
+			},
+			"bin": {
+				"stylelint": "bin/stylelint.mjs"
+			},
+			"engines": {
+				"node": "^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/stylelint"
+			}
+		},
+		"node_modules/stylelint-config-wikimedia/node_modules/typescript": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/stylelint-config-wikimedia/node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"dev": true,
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
 		},
 		"node_modules/stylelint-no-unsupported-browser-features": {
 			"version": "6.1.0",
@@ -12466,26 +12824,126 @@
 			}
 		},
 		"node_modules/stylelint-scss": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.3.0.tgz",
-			"integrity": "sha512-GvSaKCA3tipzZHoz+nNO7S02ZqOsdBzMiCx9poSmLlb3tdJlGddEX/8QzCOD8O7GQan9bjsvLMsO5xiw6IhhIQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.2.1.tgz",
+			"integrity": "sha512-ZoTJUM85/qqpQHfEppjW/St//8s6p9Qsg8deWlYlr56F9iUgC9vXeIDQvH4odkRRJLTLFQzYMALSOFCQ3MDkgw==",
 			"dev": true,
 			"dependencies": {
-				"lodash": "^4.17.21",
+				"known-css-properties": "^0.28.0",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-selector-parser": "^6.0.6",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-selector-parser": "^6.0.13",
+				"postcss-value-parser": "^4.2.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^14.5.1"
+				"stylelint": "^14.5.1 || ^15.0.0"
 			}
+		},
+		"node_modules/stylelint-stylistic": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/stylelint-stylistic/-/stylelint-stylistic-0.4.3.tgz",
+			"integrity": "sha512-WphmneK3MRrm5ixvRPWy7+c9+EQUh0FPvNMXW/N9VD85vyqtpxUejpD+mxubVVht0fRgidcqBxtW3s3tU2Ujhw==",
+			"dev": true,
+			"dependencies": {
+				"is-plain-object": "^5.0.0",
+				"postcss": "^8.4.21",
+				"postcss-media-query-parser": "^0.2.3",
+				"postcss-value-parser": "^4.2.0",
+				"style-search": "^0.1.0"
+			},
+			"peerDependencies": {
+				"stylelint": "^15.0.0"
+			}
+		},
+		"node_modules/stylelint/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
 		},
 		"node_modules/stylelint/node_modules/balanced-match": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
 			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
 			"dev": true
+		},
+		"node_modules/stylelint/node_modules/cosmiconfig": {
+			"version": "8.3.6",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+			"dev": true,
+			"dependencies": {
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0",
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/stylelint/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/stylelint/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/stylelint/node_modules/typescript": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+			"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+			"dev": true,
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/stylelint/node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+			"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+			"dev": true,
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
 		},
 		"node_modules/supports-color": {
 			"version": "5.5.0",
@@ -12499,16 +12957,16 @@
 			}
 		},
 		"node_modules/supports-hyperlinks": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+			"integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
 			"dev": true,
 			"dependencies": {
 				"has-flag": "^4.0.0",
 				"supports-color": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=14.18"
 			}
 		},
 		"node_modules/supports-hyperlinks/node_modules/has-flag": {
@@ -12808,12 +13266,15 @@
 			}
 		},
 		"node_modules/trim-newlines": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
+			"integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ts-jest": {
@@ -13104,12 +13565,6 @@
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
-		},
-		"node_modules/v8-compile-cache": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-			"dev": true
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.1.3",
@@ -14096,10 +14551,30 @@
 			"dev": true,
 			"optional": true
 		},
+		"@csstools/css-parser-algorithms": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.2.tgz",
+			"integrity": "sha512-sLYGdAdEY2x7TSw9FtmdaTrh2wFtRJO5VMbBrA8tEqEod7GEggFmxTSK9XqExib3yMuYNcvcTdCZIP6ukdjAIA==",
+			"dev": true,
+			"requires": {}
+		},
+		"@csstools/css-tokenizer": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.1.tgz",
+			"integrity": "sha512-Zmsf2f/CaEPWEVgw29odOj+WEVoiJy9s9NOv5GgNY9mZ1CZ7394By6wONrONrTsnNDv6F9hR02nvFihrGVGHBg==",
+			"dev": true
+		},
+		"@csstools/media-query-list-parser": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.5.tgz",
+			"integrity": "sha512-IxVBdYzR8pYe89JiyXQuYk4aVVoCPhMJkz6ElRwlVysjwURTsTk/bmY/z4FfeRE+CRBMlykPwXEVUg8lThv7AQ==",
+			"dev": true,
+			"requires": {}
+		},
 		"@csstools/selector-specificity": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
-			"integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz",
+			"integrity": "sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==",
 			"dev": true,
 			"requires": {}
 		},
@@ -14840,12 +15315,12 @@
 			"dev": true
 		},
 		"@namics/stylelint-bem": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@namics/stylelint-bem/-/stylelint-bem-8.1.0.tgz",
-			"integrity": "sha512-lVK6mqAD1WjKwtXW4pZ/V7T3TM3WFG+aqYtAxqYLp7et3Rm5Tu3JoXYhA63HE4t467XOJTK+K2foIzYz42j69w==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@namics/stylelint-bem/-/stylelint-bem-9.0.0.tgz",
+			"integrity": "sha512-fjEykSt5jZYo4wy4dFwqvxNz0a5yyvZa/rxpLM0kxv8y8cKKB3kBCi8XM1okMz9wHeIIg+M4vLZVg7CrlKyQdQ==",
 			"dev": true,
 			"requires": {
-				"css-selector-classes": "0.1.2",
+				"css-selector-parser": "2.3.2",
 				"postcss-resolve-nested-selector": "0.1.1"
 			}
 		},
@@ -15038,9 +15513,9 @@
 			"dev": true
 		},
 		"@types/minimist": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
-			"integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.3.tgz",
+			"integrity": "sha512-ZYFzrvyWUNhaPomn80dsMNgMeXxNWZBdkuG/hWlUvXvbdUH8ZERNBGXnU87McuGcWDsyzX2aChCv/SVN348k3A==",
 			"dev": true
 		},
 		"@types/node": {
@@ -15052,12 +15527,6 @@
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-			"dev": true
-		},
-		"@types/parse-json": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
 			"dev": true
 		},
 		"@types/semver": {
@@ -15755,12 +16224,6 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
-		"array-uniq": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
-			"dev": true
-		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -16154,14 +16617,29 @@
 			"dev": true
 		},
 		"camelcase-keys": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-			"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
+			"integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
 			"dev": true,
 			"requires": {
-				"camelcase": "^5.3.1",
-				"map-obj": "^4.0.0",
-				"quick-lru": "^4.0.1"
+				"camelcase": "^6.3.0",
+				"map-obj": "^4.1.0",
+				"quick-lru": "^5.1.1",
+				"type-fest": "^1.2.1"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+					"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+					"dev": true
+				}
 			}
 		},
 		"caniuse-lite": {
@@ -16432,27 +16910,6 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
 		},
-		"cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-			"dev": true,
-			"requires": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"dependencies": {
-				"yaml": {
-					"version": "1.10.2",
-					"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-					"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-					"dev": true
-				}
-			}
-		},
 		"create-jest": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -16531,9 +16988,9 @@
 			}
 		},
 		"css-functions-list": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
-			"integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.0.tgz",
+			"integrity": "sha512-d/jBMPyYybkkLVypgtGv12R+pIFw4/f/IHtCTxWpZc8ofTYOPigIgmA6vu5rMHartZC+WuXhBUHfnyNUIQSYrg==",
 			"dev": true
 		},
 		"css-rule-stream": {
@@ -16572,20 +17029,10 @@
 				}
 			}
 		},
-		"css-selector-classes": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/css-selector-classes/-/css-selector-classes-0.1.2.tgz",
-			"integrity": "sha512-I9BqkJUoQgd//YQfRKpk+ohVJBa1TnJjcbHGNdAy8mfrzUMpTkFDEIMQNkn8hiV1soBFGqBQcxJRoh81XhAVYw==",
-			"dev": true,
-			"requires": {
-				"array-uniq": "^1.0.2",
-				"css-selector-parser": "~1.0.3"
-			}
-		},
 		"css-selector-parser": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.0.4.tgz",
-			"integrity": "sha512-hu4/RJPZaghwTY/B7PpCt2s1Vq8qzT4UYhi279u4MB8TADfbpR3V3M9m4AnUVleQsrVkPqe/dGLbzxi4GgTg2A==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-2.3.2.tgz",
+			"integrity": "sha512-JjnG6/pdLJh3iqipq7kteNVtbIczsU2A1cNxb+VAiniSuNmrB/NI3us4rSCfArvlwRXYly+jZhUUfEoInSH9Qg==",
 			"dev": true
 		},
 		"css-tokenize": {
@@ -16599,12 +17046,12 @@
 			}
 		},
 		"css-tree": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.1.0.tgz",
-			"integrity": "sha512-PcysZRzToBbrpoUrZ9qfblRIRf8zbEAkU0AIpQFtgkFK0vSbzOmBCvdSAx2Zg7Xx5wiYJKUKk0NMP7kxevie/A==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
 			"dev": true,
 			"requires": {
-				"mdn-data": "2.0.27",
+				"mdn-data": "2.0.30",
 				"source-map-js": "^1.0.1"
 			}
 		},
@@ -16808,21 +17255,27 @@
 			}
 		},
 		"decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
 			"dev": true
 		},
 		"decamelize-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-			"integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
 			"dev": true,
 			"requires": {
 				"decamelize": "^1.1.0",
 				"map-obj": "^1.0.0"
 			},
 			"dependencies": {
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+					"dev": true
+				},
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -18217,9 +18670,9 @@
 			"dev": true
 		},
 		"fast-glob": {
-			"version": "3.2.12",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-			"integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -18669,9 +19122,9 @@
 			"dev": true
 		},
 		"html-tags": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
-			"integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+			"integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
 			"dev": true
 		},
 		"htmlparser2": {
@@ -20578,9 +21031,9 @@
 			"dev": true
 		},
 		"known-css-properties": {
-			"version": "0.26.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.26.0.tgz",
-			"integrity": "sha512-5FZRzrZzNTBruuurWpvZnvP9pum+fe0HcK8z/ooo+U+Hmp4vtbyp1/QDsqmufirXy4egGzbaH/y2uCZf+6W5Kg==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.28.0.tgz",
+			"integrity": "sha512-9pSL5XB4J+ifHP0e0jmmC98OGC1nL8/JjS+fi6mnTlIf//yt/MfVLtKg7S6nCtj/8KTcWX7nRlY0XywoYY1ISQ==",
 			"dev": true
 		},
 		"lazy-ass": {
@@ -21178,9 +21631,9 @@
 			"dev": true
 		},
 		"mdn-data": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.27.tgz",
-			"integrity": "sha512-kwqO0I0jtWr25KcfLm9pia8vLZ8qoAKhWZuZMbneJq3jjBD3gl5nZs8l8Tu3ZBlBAHVQtDur9rdDGyvtfVraHQ==",
+			"version": "2.0.30",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
 			"dev": true
 		},
 		"memorystream": {
@@ -21190,25 +21643,35 @@
 			"dev": true
 		},
 		"meow": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-			"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+			"version": "10.1.5",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.5.tgz",
+			"integrity": "sha512-/d+PQ4GKmGvM9Bee/DPa8z3mXs/pkvJE2KEThngVNOqtmljC6K7NMPxtc2JeZYTmpWb9k/TmxjeL18ez3h7vCw==",
 			"dev": true,
 			"requires": {
-				"@types/minimist": "^1.2.0",
-				"camelcase-keys": "^6.2.2",
-				"decamelize": "^1.2.0",
+				"@types/minimist": "^1.2.2",
+				"camelcase-keys": "^7.0.0",
+				"decamelize": "^5.0.0",
 				"decamelize-keys": "^1.1.0",
 				"hard-rejection": "^2.1.0",
 				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.0",
-				"read-pkg-up": "^7.0.1",
-				"redent": "^3.0.0",
-				"trim-newlines": "^3.0.0",
-				"type-fest": "^0.18.0",
-				"yargs-parser": "^20.2.3"
+				"normalize-package-data": "^3.0.2",
+				"read-pkg-up": "^8.0.0",
+				"redent": "^4.0.0",
+				"trim-newlines": "^4.0.2",
+				"type-fest": "^1.2.2",
+				"yargs-parser": "^20.2.9"
 			},
 			"dependencies": {
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
 				"hosted-git-info": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
@@ -21216,6 +21679,15 @@
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
 					}
 				},
 				"normalize-package-data": {
@@ -21230,19 +21702,60 @@
 						"validate-npm-package-license": "^3.0.1"
 					}
 				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				},
+				"read-pkg": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+					"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^3.0.2",
+						"parse-json": "^5.2.0",
+						"type-fest": "^1.0.1"
+					}
+				},
+				"read-pkg-up": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+					"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^5.0.0",
+						"read-pkg": "^6.0.0",
+						"type-fest": "^1.0.1"
+					}
+				},
 				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+					"version": "7.5.4",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
 				},
 				"type-fest": {
-					"version": "0.18.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-					"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
 					"dev": true
 				}
 			}
@@ -21793,16 +22306,16 @@
 			"requires": {}
 		},
 		"postcss-scss": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.5.tgz",
-			"integrity": "sha512-F7xpB6TrXyqUh3GKdyB4Gkp3QL3DDW1+uI+gxx/oJnUt/qXI4trj5OGlp9rOKdoABGULuqtqeG+3HEVQk4DjmA==",
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+			"integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
 			"dev": true,
 			"requires": {}
 		},
 		"postcss-selector-parser": {
-			"version": "6.0.11",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-			"integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+			"version": "6.0.13",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+			"integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
 			"dev": true,
 			"requires": {
 				"cssesc": "^3.0.0",
@@ -21940,9 +22453,9 @@
 			"dev": true
 		},
 		"quick-lru": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
 			"dev": true
 		},
 		"ramda": {
@@ -22045,13 +22558,30 @@
 			}
 		},
 		"redent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
 			"dev": true,
 			"requires": {
-				"indent-string": "^4.0.0",
-				"strip-indent": "^3.0.0"
+				"indent-string": "^5.0.0",
+				"strip-indent": "^4.0.0"
+			},
+			"dependencies": {
+				"indent-string": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+					"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+					"dev": true
+				},
+				"strip-indent": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+					"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+					"dev": true,
+					"requires": {
+						"min-indent": "^1.0.1"
+					}
+				}
 			}
 		},
 		"regexp-tree": {
@@ -22647,56 +23177,109 @@
 			"dev": true
 		},
 		"stylelint": {
-			"version": "14.16.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
-			"integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
+			"version": "15.10.3",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.3.tgz",
+			"integrity": "sha512-aBQMMxYvFzJJwkmg+BUUg3YfPyeuCuKo2f+LOw7yYbU8AZMblibwzp9OV4srHVeQldxvSFdz0/Xu8blq2AesiA==",
 			"dev": true,
 			"requires": {
-				"@csstools/selector-specificity": "^2.0.2",
+				"@csstools/css-parser-algorithms": "^2.3.1",
+				"@csstools/css-tokenizer": "^2.2.0",
+				"@csstools/media-query-list-parser": "^2.1.4",
+				"@csstools/selector-specificity": "^3.0.0",
 				"balanced-match": "^2.0.0",
 				"colord": "^2.9.3",
-				"cosmiconfig": "^7.1.0",
-				"css-functions-list": "^3.1.0",
+				"cosmiconfig": "^8.2.0",
+				"css-functions-list": "^3.2.0",
+				"css-tree": "^2.3.1",
 				"debug": "^4.3.4",
-				"fast-glob": "^3.2.12",
+				"fast-glob": "^3.3.1",
 				"fastest-levenshtein": "^1.0.16",
 				"file-entry-cache": "^6.0.1",
 				"global-modules": "^2.0.0",
 				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
-				"html-tags": "^3.2.0",
-				"ignore": "^5.2.1",
+				"html-tags": "^3.3.1",
+				"ignore": "^5.2.4",
 				"import-lazy": "^4.0.0",
 				"imurmurhash": "^0.1.4",
 				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.26.0",
+				"known-css-properties": "^0.28.0",
 				"mathml-tag-names": "^2.1.3",
-				"meow": "^9.0.0",
+				"meow": "^10.1.5",
 				"micromatch": "^4.0.5",
 				"normalize-path": "^3.0.0",
 				"picocolors": "^1.0.0",
-				"postcss": "^8.4.19",
-				"postcss-media-query-parser": "^0.2.3",
+				"postcss": "^8.4.27",
 				"postcss-resolve-nested-selector": "^0.1.1",
 				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.11",
+				"postcss-selector-parser": "^6.0.13",
 				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
 				"string-width": "^4.2.3",
 				"strip-ansi": "^6.0.1",
 				"style-search": "^0.1.0",
-				"supports-hyperlinks": "^2.3.0",
+				"supports-hyperlinks": "^3.0.0",
 				"svg-tags": "^1.0.0",
 				"table": "^6.8.1",
-				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^4.0.2"
+				"write-file-atomic": "^5.0.1"
 			},
 			"dependencies": {
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
 				"balanced-match": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
 					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
 					"dev": true
+				},
+				"cosmiconfig": {
+					"version": "8.3.6",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+					"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+					"dev": true,
+					"requires": {
+						"import-fresh": "^3.3.0",
+						"js-yaml": "^4.1.0",
+						"parse-json": "^5.2.0",
+						"path-type": "^4.0.0"
+					}
+				},
+				"js-yaml": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"dev": true,
+					"requires": {
+						"argparse": "^2.0.1"
+					}
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				},
+				"typescript": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+					"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+					"dev": true,
+					"optional": true,
+					"peer": true
+				},
+				"write-file-atomic": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+					"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^4.0.1"
+					}
 				}
 			}
 		},
@@ -22708,21 +23291,21 @@
 			"requires": {}
 		},
 		"stylelint-config-recommended": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz",
-			"integrity": "sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-13.0.0.tgz",
+			"integrity": "sha512-EH+yRj6h3GAe/fRiyaoO2F9l9Tgg50AOFhaszyfov9v6ayXJ1IkSHwTxd7lB48FmOeSGDPLjatjO11fJpmarkQ==",
 			"dev": true,
 			"requires": {}
 		},
 		"stylelint-config-recommended-scss": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-8.0.0.tgz",
-			"integrity": "sha512-BxjxEzRaZoQb7Iinc3p92GS6zRdRAkIuEu2ZFLTxJK2e1AIcCb5B5MXY9KOXdGTnYFZ+KKx6R4Fv9zU6CtMYPQ==",
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-13.0.0.tgz",
+			"integrity": "sha512-7AmMIsHTsuwUQm7I+DD5BGeIgCvqYZ4BpeYJJpb1cUXQwrJAKjA+GBotFZgUEGP8lAM+wmd91ovzOi8xfAyWEw==",
 			"dev": true,
 			"requires": {
-				"postcss-scss": "^4.0.2",
-				"stylelint-config-recommended": "^9.0.0",
-				"stylelint-scss": "^4.0.0"
+				"postcss-scss": "^4.0.7",
+				"stylelint-config-recommended": "^13.0.0",
+				"stylelint-scss": "^5.1.0"
 			}
 		},
 		"stylelint-config-recommended-vue": {
@@ -22748,43 +23331,155 @@
 			}
 		},
 		"stylelint-config-standard": {
-			"version": "29.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-29.0.0.tgz",
-			"integrity": "sha512-uy8tZLbfq6ZrXy4JKu3W+7lYLgRQBxYTUUB88vPgQ+ZzAxdrvcaSUW9hOMNLYBnwH+9Kkj19M2DHdZ4gKwI7tg==",
+			"version": "34.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-34.0.0.tgz",
+			"integrity": "sha512-u0VSZnVyW9VSryBG2LSO+OQTjN7zF9XJaAJRX/4EwkmU0R2jYwmBSN10acqZisDitS0CLiEiGjX7+Hrq8TAhfQ==",
 			"dev": true,
 			"requires": {
-				"stylelint-config-recommended": "^9.0.0"
+				"stylelint-config-recommended": "^13.0.0"
 			}
 		},
 		"stylelint-config-standard-scss": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-6.1.0.tgz",
-			"integrity": "sha512-iZ2B5kQT2G3rUzx+437cEpdcnFOQkwnwqXuY8Z0QUwIHQVE8mnYChGAquyKFUKZRZ0pRnrciARlPaR1RBtPb0Q==",
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-11.0.0.tgz",
+			"integrity": "sha512-fGE79NBOLg09a9afqGH/guJulRULCaQWWv4cv1v2bMX92B+fGb0y56WqIguwvFcliPmmUXiAhKrrnXilIeXoHA==",
 			"dev": true,
 			"requires": {
-				"stylelint-config-recommended-scss": "^8.0.0",
-				"stylelint-config-standard": "^29.0.0"
+				"stylelint-config-recommended-scss": "^13.0.0",
+				"stylelint-config-standard": "^34.0.0"
 			}
 		},
 		"stylelint-config-wikimedia": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-wikimedia/-/stylelint-config-wikimedia-0.15.0.tgz",
-			"integrity": "sha512-8cQ1qGbvA6qwmH+sT2m2h/yha77z564WRhuXJTD9rQl+IhN5R8nTdu9QKSCikB/mTQ/xmldsvcmA2YsTavO3ig==",
+			"version": "0.16.1",
+			"resolved": "https://registry.npmjs.org/stylelint-config-wikimedia/-/stylelint-config-wikimedia-0.16.1.tgz",
+			"integrity": "sha512-FDVUyDyCBap2o2HAeJqIobdVdSTur5HFX5FymoKrzfMIYWxIV/55lTpyL1PR71TfVMaroDXJrIftLFW9mXKFhQ==",
 			"dev": true,
 			"requires": {
 				"browserslist-config-wikimedia": "0.5.0",
 				"postcss-html": "1.5.0",
 				"postcss-less": "6.0.0",
-				"stylelint": "14.16.1",
-				"stylelint-config-recommended": "9.0.0",
-				"stylelint-no-unsupported-browser-features": "6.1.0"
+				"stylelint": "15.10.1",
+				"stylelint-config-recommended": "13.0.0",
+				"stylelint-no-unsupported-browser-features": "6.1.0",
+				"stylelint-stylistic": "0.4.3"
 			},
 			"dependencies": {
+				"argparse": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+					"dev": true
+				},
+				"balanced-match": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+					"dev": true
+				},
 				"browserslist-config-wikimedia": {
 					"version": "0.5.0",
 					"resolved": "https://registry.npmjs.org/browserslist-config-wikimedia/-/browserslist-config-wikimedia-0.5.0.tgz",
 					"integrity": "sha512-t+tvSnTeVhVF2lNRxoAlE51/ZCfUs5SNNZUnWu2N8xXOGMPTMyKk5l4mayvDdm+5L8oqmnALU+TjnN2Z+ZTCTw==",
 					"dev": true
+				},
+				"cosmiconfig": {
+					"version": "8.3.6",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+					"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+					"dev": true,
+					"requires": {
+						"import-fresh": "^3.3.0",
+						"js-yaml": "^4.1.0",
+						"parse-json": "^5.2.0",
+						"path-type": "^4.0.0"
+					}
+				},
+				"js-yaml": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+					"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+					"dev": true,
+					"requires": {
+						"argparse": "^2.0.1"
+					}
+				},
+				"known-css-properties": {
+					"version": "0.27.0",
+					"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.27.0.tgz",
+					"integrity": "sha512-uMCj6+hZYDoffuvAJjFAPz56E9uoowFHmTkqRtRq5WyC5Q6Cu/fTZKNQpX/RbzChBYLLl3lo8CjFZBAZXq9qFg==",
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+					"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+					"dev": true
+				},
+				"stylelint": {
+					"version": "15.10.1",
+					"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.10.1.tgz",
+					"integrity": "sha512-CYkzYrCFfA/gnOR+u9kJ1PpzwG10WLVnoxHDuBA/JiwGqdM9+yx9+ou6SE/y9YHtfv1mcLo06fdadHTOx4gBZQ==",
+					"dev": true,
+					"requires": {
+						"@csstools/css-parser-algorithms": "^2.3.0",
+						"@csstools/css-tokenizer": "^2.1.1",
+						"@csstools/media-query-list-parser": "^2.1.2",
+						"@csstools/selector-specificity": "^3.0.0",
+						"balanced-match": "^2.0.0",
+						"colord": "^2.9.3",
+						"cosmiconfig": "^8.2.0",
+						"css-functions-list": "^3.1.0",
+						"css-tree": "^2.3.1",
+						"debug": "^4.3.4",
+						"fast-glob": "^3.3.0",
+						"fastest-levenshtein": "^1.0.16",
+						"file-entry-cache": "^6.0.1",
+						"global-modules": "^2.0.0",
+						"globby": "^11.1.0",
+						"globjoin": "^0.1.4",
+						"html-tags": "^3.3.1",
+						"ignore": "^5.2.4",
+						"import-lazy": "^4.0.0",
+						"imurmurhash": "^0.1.4",
+						"is-plain-object": "^5.0.0",
+						"known-css-properties": "^0.27.0",
+						"mathml-tag-names": "^2.1.3",
+						"meow": "^10.1.5",
+						"micromatch": "^4.0.5",
+						"normalize-path": "^3.0.0",
+						"picocolors": "^1.0.0",
+						"postcss": "^8.4.24",
+						"postcss-resolve-nested-selector": "^0.1.1",
+						"postcss-safe-parser": "^6.0.0",
+						"postcss-selector-parser": "^6.0.13",
+						"postcss-value-parser": "^4.2.0",
+						"resolve-from": "^5.0.0",
+						"string-width": "^4.2.3",
+						"strip-ansi": "^6.0.1",
+						"style-search": "^0.1.0",
+						"supports-hyperlinks": "^3.0.0",
+						"svg-tags": "^1.0.0",
+						"table": "^6.8.1",
+						"write-file-atomic": "^5.0.1"
+					}
+				},
+				"typescript": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+					"integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+					"dev": true,
+					"optional": true,
+					"peer": true
+				},
+				"write-file-atomic": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+					"integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^4.0.1"
+					}
 				}
 			}
 		},
@@ -22800,16 +23495,29 @@
 			}
 		},
 		"stylelint-scss": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.3.0.tgz",
-			"integrity": "sha512-GvSaKCA3tipzZHoz+nNO7S02ZqOsdBzMiCx9poSmLlb3tdJlGddEX/8QzCOD8O7GQan9bjsvLMsO5xiw6IhhIQ==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-5.2.1.tgz",
+			"integrity": "sha512-ZoTJUM85/qqpQHfEppjW/St//8s6p9Qsg8deWlYlr56F9iUgC9vXeIDQvH4odkRRJLTLFQzYMALSOFCQ3MDkgw==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.21",
+				"known-css-properties": "^0.28.0",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-selector-parser": "^6.0.6",
-				"postcss-value-parser": "^4.1.0"
+				"postcss-selector-parser": "^6.0.13",
+				"postcss-value-parser": "^4.2.0"
+			}
+		},
+		"stylelint-stylistic": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/stylelint-stylistic/-/stylelint-stylistic-0.4.3.tgz",
+			"integrity": "sha512-WphmneK3MRrm5ixvRPWy7+c9+EQUh0FPvNMXW/N9VD85vyqtpxUejpD+mxubVVht0fRgidcqBxtW3s3tU2Ujhw==",
+			"dev": true,
+			"requires": {
+				"is-plain-object": "^5.0.0",
+				"postcss": "^8.4.21",
+				"postcss-media-query-parser": "^0.2.3",
+				"postcss-value-parser": "^4.2.0",
+				"style-search": "^0.1.0"
 			}
 		},
 		"supports-color": {
@@ -22821,9 +23529,9 @@
 			}
 		},
 		"supports-hyperlinks": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
-			"integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+			"integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
 			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0",
@@ -23060,9 +23768,9 @@
 			}
 		},
 		"trim-newlines": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
+			"integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
 			"dev": true
 		},
 		"ts-jest": {
@@ -23256,12 +23964,6 @@
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true
-		},
-		"v8-compile-cache": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
-			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
 		"v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"vuex": "^4.0.2"
 	},
 	"devDependencies": {
-		"@namics/stylelint-bem": "^8.1.0",
+		"@namics/stylelint-bem": "^9.0.0",
 		"@rushstack/eslint-patch": "^1.3.2",
 		"@types/jest": "^29.5.5",
 		"@types/lodash": "^4.14.199",
@@ -78,10 +78,10 @@
 		"prettier": "^2.8.8",
 		"sass": "^1.69.0",
 		"start-server-and-test": "^2.0.0",
-		"stylelint": "^14.16.1",
+		"stylelint": "^15.10.3",
 		"stylelint-config-recommended-vue": "^1.5.0",
-		"stylelint-config-standard-scss": "^6.1.0",
-		"stylelint-config-wikimedia": "^0.15.0",
+		"stylelint-config-standard-scss": "^11.0.0",
+		"stylelint-config-wikimedia": "^0.16.1",
 		"ts-jest": "^29.1.1",
 		"typescript": "~4.7.0",
 		"vite": "^3.2.7",

--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -79,12 +79,12 @@ export default {
 </template>
 
 <style lang="scss">
-@import "@wmde/wikit-tokens/variables";
+@import '@wmde/wikit-tokens/variables';
 
-/* stylelint-disable plugin/stylelint-bem-namics, selector-class-pattern */
+/* stylelint-disable selector-class-pattern */
 .wbl-snl-language-lookup .wikit .wikit-Lookup__label-wrapper {
 	gap: $dimension-spacing-xsmall;
 }
-/* stylelint-enable plugin/stylelint-bem-namics, selector-class-pattern */
+/* stylelint-enable selector-class-pattern */
 
 </style>

--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -71,7 +71,7 @@ export default {
 </template>
 
 <style lang="scss">
-@import "@wmde/wikit-tokens/variables";
+@import '@wmde/wikit-tokens/variables';
 
 /* stylelint-disable plugin/stylelint-bem-namics, selector-class-pattern */
 .wbl-snl-lemma-input.wikit .wikit-TextInput__label-wrapper {

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -73,11 +73,11 @@ export default {
 </template>
 
 <style lang="scss">
-@import "@wmde/wikit-tokens/variables";
-/* stylelint-disable plugin/stylelint-bem-namics, selector-class-pattern */
+@import '@wmde/wikit-tokens/variables';
+/* stylelint-disable selector-class-pattern */
 .wbl-snl-lexical-category-lookup .wikit .wikit-Lookup__label-wrapper {
 	gap: $dimension-spacing-xsmall;
 }
-/* stylelint-enable plugin/stylelint-bem-namics, selector-class-pattern */
+/* stylelint-enable selector-class-pattern */
 
 </style>

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -190,8 +190,8 @@ export default {
 </template>
 
 <style scoped lang="scss">
-@import "@wmde/wikit-tokens/variables";
-@import "@wmde/wikit-vue-components/src/styles/mixins/Typography";
+@import '@wmde/wikit-tokens/variables';
+@import '@wmde/wikit-vue-components/src/styles/mixins/Typography';
 
 .wbl-snl-form {
 	& > * + * {

--- a/src/components/RequiredAsterisk.vue
+++ b/src/components/RequiredAsterisk.vue
@@ -21,17 +21,17 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-@import "@wmde/wikit-tokens/variables";
+@import '@wmde/wikit-tokens/variables';
 
 .wbl-snl-required-asterisk {
 	font-size: $font-size-xxlarge;
 	line-height: 0;
 
-	&:not(:first-child) {
+	&:not( :first-child ) {
 		margin-inline-start: $dimension-spacing-small;
 	}
 
-	&:not(:last-child) {
+	&:not( :last-child ) {
 		margin-inline-end: $dimension-spacing-small;
 	}
 }

--- a/src/components/SearchExisting.vue
+++ b/src/components/SearchExisting.vue
@@ -24,8 +24,8 @@ const searchMessage = computed( () => messages.get(
 </template>
 
 <style lang="scss" scoped>
-@import "@wmde/wikit-tokens/variables";
-@import "@wmde/wikit-vue-components/src/styles/mixins/Typography";
+@import '@wmde/wikit-tokens/variables';
+@import '@wmde/wikit-vue-components/src/styles/mixins/Typography';
 
 .wbl-snl-search-existing {
 	@include body;

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -127,7 +127,7 @@ export default {
 </template>
 
 <style lang="scss">
-@import "@wmde/wikit-tokens/variables";
+@import '@wmde/wikit-tokens/variables';
 
 .wbl-snl-spelling-variant-lookup {
 	/* stylelint-disable plugin/stylelint-bem-namics, selector-class-pattern */


### PR DESCRIPTION
```bash
npm i {stylelint{,-config-{standard-scss,wikimedia}},@namics/stylelint-bem}@latest
```

Most of the changes are made by `npm run fix:stylelint`; removing the now-unused disabling of plugin/stylelint-bem-namics in LanguageInput and LexicalCategoryInput was done manually.

Bug: T348108