### PR TITLE
Compare language codes case-insensitive

### DIFF
--- a/src/data-access/LanguageCodesProvider.ts
+++ b/src/data-access/LanguageCodesProvider.ts
@@ -18,6 +18,6 @@ export class MapLanguageCodesProvider implements LanguageCodesProvider {
 	}
 
 	public isValid( langCode: string ): boolean {
-		return this.validLanguages.has( langCode );
+		return this.validLanguages.has( langCode.toLowerCase() );
 	}
 }

--- a/tests/unit/data-access/LangCodeProvider.test.ts
+++ b/tests/unit/data-access/LangCodeProvider.test.ts
@@ -10,6 +10,14 @@ describe( 'MapLanguageCodesProvider', () => {
 
 			expect( actual ).toBe( true );
 		} );
+		it( 'it returns true for valid language codes regardless of case', () => {
+			const listOfValidCodes = new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
+			const sut = new MapLanguageCodesProvider( listOfValidCodes );
+
+			const actual = sut.isValid( 'en-GB' );
+
+			expect( actual ).toBe( true );
+		} );
 		it( 'returns "false" for an invalid language code', () => {
 			const listOfValidCodes = new Map( [ [ 'en', 'English' ], [ 'en-gb', 'British English' ], [ 'de', 'German' ] ] );
 			const sut = new MapLanguageCodesProvider( listOfValidCodes );


### PR DESCRIPTION
When switching to getting the language codes for a language from the IETF-code property in T348923, we also get a lot of composite codes for language variants that are partially uppercased, like en-GB or pt-BR. However, in our data, they are stored as completely lowercase strings. Thus, without this change, the user still has to manually, yet needlessly, select the valid language code from the dropdown.

TODO:
- [ ] this also has to work when _saving_ the statement, where the API also requires a fully lowercase language code