### PR TITLE
DevLangCodeRetriever: Adjust property-id used for language code

### DIFF
--- a/src/data-access/DevLangCodeRetriever.ts
+++ b/src/data-access/DevLangCodeRetriever.ts
@@ -6,7 +6,7 @@ export default class DevLangCodeRetriever implements LangCodeRetriever {
 		const response = await fetch( 'https://www.wikidata.org/w/api.php?' + new URLSearchParams( {
 			action: 'wbgetclaims',
 			entity: itemId,
-			property: 'P218',
+			property: 'P305',
 			props: '',
 			format: 'json',
 			origin: '*',


### PR DESCRIPTION
This was changed in production to user the broader coverage provided by IETF code, see T348923.

Bug: T348923