### PR TITLE
Lowercase language code from item statement

### DIFF
--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -221,6 +221,9 @@ export default function createActions(
 			{ commit }: RootContext,
 			languageCode: string | undefined | null | false,
 		) {
+			if ( typeof languageCode === 'string' ) {
+				languageCode = languageCode.toLowerCase(); // T349652
+			}
 			if ( typeof languageCode === 'string' && !languageCodesProvider.isValid( languageCode ) ) {
 				languageCode = false;
 			}

--- a/tests/unit/store/actions.test.ts
+++ b/tests/unit/store/actions.test.ts
@@ -355,7 +355,8 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 	} );
 
 	it( 'validates and sets to state if valid lang code was returned', async () => {
-		const getLanguageCodeFromItemMock = jest.fn().mockResolvedValue( 'de' );
+		// T349652: en-GB from item (preferred IETF lanugage tag format) is lowercased to en-gb (MediaWiki code)
+		const getLanguageCodeFromItemMock = jest.fn().mockResolvedValue( 'en-GB' );
 		const isValidMock = jest.fn().mockReturnValue( true );
 		const actions = createActions(
 			unusedLexemeCreator,
@@ -387,9 +388,9 @@ describe( 'HANDLE_LANGUAGE_CHANGE', () => {
 
 		expect( store.state.language ).toStrictEqual( { id: 'Q456' } );
 		expect( store.state.spellingVariant ).toBe( '' );
-		expect( store.state.languageCodeFromLanguageItem ).toBe( 'de' );
+		expect( store.state.languageCodeFromLanguageItem ).toBe( 'en-gb' );
 		expect( getLanguageCodeFromItemMock ).toHaveBeenCalledWith( 'Q456' );
-		expect( isValidMock ).toHaveBeenCalledWith( 'de' );
+		expect( isValidMock ).toHaveBeenCalledWith( 'en-gb' );
 	} );
 
 	it( 'validates and sets false state if invalid lang code was returned', async () => {


### PR DESCRIPTION
We now use the property “IETF language tag” for the automatic language code on Wikidata; the subtag of these tags is case-insensitive, but some capitalization is recommended.<sup>[1][1], [2][2]</sup> For MediaWiki or Wikidata, on the other hand, the subtags generally need to be all-lowercase (except our special mis-x-Qid codes, see T317863). Reconcile this by lowercasing all language codes from items in the store action.

[1]: https://en.wikipedia.org/wiki/IETF_language_tag#Syntax_of_language_tags
[2]: https://en.wikipedia.org/w/index.php?title=IETF_language_tag&oldid=1181524280#Syntax_of_language_tags

Bug: T349652