### PR TITLE
Upgrade Vue from v3.2.27 to v3.3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@wmde/wikit-tokens": "^3.0.0-alpha.12",
 				"@wmde/wikit-vue-components": "^3.0.0-alpha.12",
 				"jest-environment-jsdom": "^29.7.0",
-				"vue": "^3.2.38",
+				"vue": "3.3.9",
 				"vuex": "^4.0.2"
 			},
 			"devDependencies": {
@@ -1952,10 +1952,9 @@
 			}
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-			"dev": true
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.19",
@@ -2548,6 +2547,8 @@
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.38.tgz",
 			"integrity": "sha512-/FsvnSu7Z+lkd/8KXMa4yYNUiqQrI22135gfsQYVGuh5tqEgOB0XqrUdb/KnCLa5+TmQLPwvyUnKMyCpu+SX3Q==",
+			"dev": true,
+			"optional": true,
 			"dependencies": {
 				"@babel/parser": "^7.16.4",
 				"@vue/shared": "3.2.38",
@@ -2558,12 +2559,16 @@
 		"node_modules/@vue/compiler-core/node_modules/@vue/shared": {
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
+			"dev": true,
+			"optional": true
 		},
 		"node_modules/@vue/compiler-core/node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2572,6 +2577,8 @@
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.38.tgz",
 			"integrity": "sha512-zqX4FgUbw56kzHlgYuEEJR8mefFiiyR3u96498+zWPsLeh1WKvgIReoNE+U7gG8bCUdvsrJ0JRmev0Ky6n2O0g==",
+			"dev": true,
+			"optional": true,
 			"dependencies": {
 				"@vue/compiler-core": "3.2.38",
 				"@vue/shared": "3.2.38"
@@ -2580,42 +2587,67 @@
 		"node_modules/@vue/compiler-dom/node_modules/@vue/shared": {
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
+			"dev": true,
+			"optional": true
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.38.tgz",
-			"integrity": "sha512-KZjrW32KloMYtTcHAFuw3CqsyWc5X6seb8KbkANSWt3Cz9p2qA8c1GJpSkksFP9ABb6an0FLCFl46ZFXx3kKpg==",
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.9.tgz",
+			"integrity": "sha512-wy0CNc8z4ihoDzjASCOCsQuzW0A/HP27+0MDSSICMjVIFzk/rFViezkR3dzH+miS2NDEz8ywMdbjO5ylhOLI2A==",
 			"dependencies": {
-				"@babel/parser": "^7.16.4",
-				"@vue/compiler-core": "3.2.38",
-				"@vue/compiler-dom": "3.2.38",
-				"@vue/compiler-ssr": "3.2.38",
-				"@vue/reactivity-transform": "3.2.38",
-				"@vue/shared": "3.2.38",
+				"@babel/parser": "^7.23.3",
+				"@vue/compiler-core": "3.3.9",
+				"@vue/compiler-dom": "3.3.9",
+				"@vue/compiler-ssr": "3.3.9",
+				"@vue/reactivity-transform": "3.3.9",
+				"@vue/shared": "3.3.9",
 				"estree-walker": "^2.0.2",
-				"magic-string": "^0.25.7",
-				"postcss": "^8.1.10",
-				"source-map": "^0.6.1"
+				"magic-string": "^0.30.5",
+				"postcss": "^8.4.31",
+				"source-map-js": "^1.0.2"
+			}
+		},
+		"node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-core": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
+			"integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
+			"dependencies": {
+				"@babel/parser": "^7.23.3",
+				"@vue/shared": "3.3.9",
+				"estree-walker": "^2.0.2",
+				"source-map-js": "^1.0.2"
+			}
+		},
+		"node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-dom": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz",
+			"integrity": "sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==",
+			"dependencies": {
+				"@vue/compiler-core": "3.3.9",
+				"@vue/shared": "3.3.9"
+			}
+		},
+		"node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-ssr": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.9.tgz",
+			"integrity": "sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==",
+			"dependencies": {
+				"@vue/compiler-dom": "3.3.9",
+				"@vue/shared": "3.3.9"
 			}
 		},
 		"node_modules/@vue/compiler-sfc/node_modules/@vue/shared": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
-		},
-		"node_modules/@vue/compiler-sfc/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"engines": {
-				"node": ">=0.10.0"
-			}
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+			"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
 		},
 		"node_modules/@vue/compiler-ssr": {
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.38.tgz",
 			"integrity": "sha512-bm9jOeyv1H3UskNm4S6IfueKjUNFmi2kRweFIGnqaGkkRePjwEcfCVqyS3roe7HvF4ugsEkhf4+kIvDhip6XzQ==",
+			"dev": true,
+			"optional": true,
 			"dependencies": {
 				"@vue/compiler-dom": "3.2.38",
 				"@vue/shared": "3.2.38"
@@ -2624,7 +2656,9 @@
 		"node_modules/@vue/compiler-ssr/node_modules/@vue/shared": {
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
+			"dev": true,
+			"optional": true
 		},
 		"node_modules/@vue/devtools-api": {
 			"version": "6.1.4",
@@ -2725,64 +2759,82 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@vue/reactivity-transform": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.38.tgz",
-			"integrity": "sha512-3SD3Jmi1yXrDwiNJqQ6fs1x61WsDLqVk4NyKVz78mkaIRh6d3IqtRnptgRfXn+Fzf+m6B1KxBYWq1APj6h4qeA==",
+		"node_modules/@vue/reactivity": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.9.tgz",
+			"integrity": "sha512-VmpIqlNp+aYDg2X0xQhJqHx9YguOmz2UxuUJDckBdQCNkipJvfk9yA75woLWElCa0Jtyec3lAAt49GO0izsphw==",
 			"dependencies": {
-				"@babel/parser": "^7.16.4",
-				"@vue/compiler-core": "3.2.38",
-				"@vue/shared": "3.2.38",
+				"@vue/shared": "3.3.9"
+			}
+		},
+		"node_modules/@vue/reactivity-transform": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.9.tgz",
+			"integrity": "sha512-HnUFm7Ry6dFa4Lp63DAxTixUp8opMtQr6RxQCpDI1vlh12rkGIeYqMvJtK+IKyEfEOa2I9oCkD1mmsPdaGpdVg==",
+			"dependencies": {
+				"@babel/parser": "^7.23.3",
+				"@vue/compiler-core": "3.3.9",
+				"@vue/shared": "3.3.9",
 				"estree-walker": "^2.0.2",
-				"magic-string": "^0.25.7"
+				"magic-string": "^0.30.5"
+			}
+		},
+		"node_modules/@vue/reactivity-transform/node_modules/@vue/compiler-core": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
+			"integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
+			"dependencies": {
+				"@babel/parser": "^7.23.3",
+				"@vue/shared": "3.3.9",
+				"estree-walker": "^2.0.2",
+				"source-map-js": "^1.0.2"
 			}
 		},
 		"node_modules/@vue/reactivity-transform/node_modules/@vue/shared": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+			"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
+		},
+		"node_modules/@vue/reactivity/node_modules/@vue/shared": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+			"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
 		},
 		"node_modules/@vue/runtime-core": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.38.tgz",
-			"integrity": "sha512-kk0qiSiXUU/IKxZw31824rxmFzrLr3TL6ZcbrxWTKivadoKupdlzbQM4SlGo4MU6Zzrqv4fzyUasTU1jDoEnzg==",
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.9.tgz",
+			"integrity": "sha512-xxaG9KvPm3GTRuM4ZyU8Tc+pMVzcu6eeoSRQJ9IE7NmCcClW6z4B3Ij6L4EDl80sxe/arTtQ6YmgiO4UZqRc+w==",
 			"dependencies": {
-				"@vue/reactivity": "3.2.38",
-				"@vue/shared": "3.2.38"
-			}
-		},
-		"node_modules/@vue/runtime-core/node_modules/@vue/reactivity": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.38.tgz",
-			"integrity": "sha512-6L4myYcH9HG2M25co7/BSo0skKFHpAN8PhkNPM4xRVkyGl1K5M3Jx4rp5bsYhvYze2K4+l+pioN4e6ZwFLUVtw==",
-			"dependencies": {
-				"@vue/shared": "3.2.38"
+				"@vue/reactivity": "3.3.9",
+				"@vue/shared": "3.3.9"
 			}
 		},
 		"node_modules/@vue/runtime-core/node_modules/@vue/shared": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+			"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
 		},
 		"node_modules/@vue/runtime-dom": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.38.tgz",
-			"integrity": "sha512-4PKAb/ck2TjxdMSzMsnHViOrrwpudk4/A56uZjhzvusoEU9xqa5dygksbzYepdZeB5NqtRw5fRhWIiQlRVK45A==",
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.9.tgz",
+			"integrity": "sha512-e7LIfcxYSWbV6BK1wQv9qJyxprC75EvSqF/kQKe6bdZEDNValzeRXEVgiX7AHI6hZ59HA4h7WT5CGvm69vzJTQ==",
 			"dependencies": {
-				"@vue/runtime-core": "3.2.38",
-				"@vue/shared": "3.2.38",
-				"csstype": "^2.6.8"
+				"@vue/runtime-core": "3.3.9",
+				"@vue/shared": "3.3.9",
+				"csstype": "^3.1.2"
 			}
 		},
 		"node_modules/@vue/runtime-dom/node_modules/@vue/shared": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+			"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
 		},
 		"node_modules/@vue/server-renderer": {
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.38.tgz",
 			"integrity": "sha512-pg+JanpbOZ5kEfOZzO2bt02YHd+ELhYP8zPeLU1H0e7lg079NtuuSB8fjLdn58c4Ou8UQ6C1/P+528nXnLPAhA==",
+			"dev": true,
+			"optional": true,
 			"dependencies": {
 				"@vue/compiler-ssr": "3.2.38",
 				"@vue/shared": "3.2.38"
@@ -2794,7 +2846,9 @@
 		"node_modules/@vue/server-renderer/node_modules/@vue/shared": {
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
+			"dev": true,
+			"optional": true
 		},
 		"node_modules/@vue/shared": {
 			"version": "3.3.8",
@@ -4252,9 +4306,9 @@
 			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
 		},
 		"node_modules/csstype": {
-			"version": "2.6.20",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-			"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
 		},
 		"node_modules/cypress": {
 			"version": "13.5.1",
@@ -10315,11 +10369,14 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"version": "0.30.5",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
 			"dependencies": {
-				"sourcemap-codec": "^1.4.8"
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/make-dir": {
@@ -12167,11 +12224,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/sourcemap-codec": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-		},
 		"node_modules/spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -13533,7 +13585,7 @@
 			"version": "4.7.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
 			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-			"dev": true,
+			"devOptional": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -13760,15 +13812,23 @@
 			"dev": true
 		},
 		"node_modules/vue": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.2.38.tgz",
-			"integrity": "sha512-hHrScEFSmDAWL0cwO4B6WO7D3sALZPbfuThDsGBebthrNlDxdJZpGR3WB87VbjpPh96mep1+KzukYEhpHDFa8Q==",
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.3.9.tgz",
+			"integrity": "sha512-sy5sLCTR8m6tvUk1/ijri3Yqzgpdsmxgj6n6yl7GXXCXqVbmW2RCXe9atE4cEI6Iv7L89v5f35fZRRr5dChP9w==",
 			"dependencies": {
-				"@vue/compiler-dom": "3.2.38",
-				"@vue/compiler-sfc": "3.2.38",
-				"@vue/runtime-dom": "3.2.38",
-				"@vue/server-renderer": "3.2.38",
-				"@vue/shared": "3.2.38"
+				"@vue/compiler-dom": "3.3.9",
+				"@vue/compiler-sfc": "3.3.9",
+				"@vue/runtime-dom": "3.3.9",
+				"@vue/server-renderer": "3.3.9",
+				"@vue/shared": "3.3.9"
+			},
+			"peerDependencies": {
+				"typescript": "*"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/vue-eslint-parser": {
@@ -13852,10 +13912,51 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/vue/node_modules/@vue/compiler-core": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
+			"integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
+			"dependencies": {
+				"@babel/parser": "^7.23.3",
+				"@vue/shared": "3.3.9",
+				"estree-walker": "^2.0.2",
+				"source-map-js": "^1.0.2"
+			}
+		},
+		"node_modules/vue/node_modules/@vue/compiler-dom": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz",
+			"integrity": "sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==",
+			"dependencies": {
+				"@vue/compiler-core": "3.3.9",
+				"@vue/shared": "3.3.9"
+			}
+		},
+		"node_modules/vue/node_modules/@vue/compiler-ssr": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.9.tgz",
+			"integrity": "sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==",
+			"dependencies": {
+				"@vue/compiler-dom": "3.3.9",
+				"@vue/shared": "3.3.9"
+			}
+		},
+		"node_modules/vue/node_modules/@vue/server-renderer": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.9.tgz",
+			"integrity": "sha512-w0zT/s5l3Oa3ZjtLW88eO4uV6AQFqU8X5GOgzq7SkQQu6vVr+8tfm+OI2kDBplS/W/XgCBuFXiPw6T5EdwXP0A==",
+			"dependencies": {
+				"@vue/compiler-ssr": "3.3.9",
+				"@vue/shared": "3.3.9"
+			},
+			"peerDependencies": {
+				"vue": "3.3.9"
+			}
+		},
 		"node_modules/vue/node_modules/@vue/shared": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-			"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+			"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
 		},
 		"node_modules/vuex": {
 			"version": "4.0.2",
@@ -15500,10 +15601,9 @@
 			"dev": true
 		},
 		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.14",
-			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-			"dev": true
+			"version": "1.4.15",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.19",
@@ -15971,6 +16071,8 @@
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.38.tgz",
 			"integrity": "sha512-/FsvnSu7Z+lkd/8KXMa4yYNUiqQrI22135gfsQYVGuh5tqEgOB0XqrUdb/KnCLa5+TmQLPwvyUnKMyCpu+SX3Q==",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"@babel/parser": "^7.16.4",
 				"@vue/shared": "3.2.38",
@@ -15981,12 +16083,16 @@
 				"@vue/shared": {
 					"version": "3.2.38",
 					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
+					"dev": true,
+					"optional": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -15994,6 +16100,8 @@
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.38.tgz",
 			"integrity": "sha512-zqX4FgUbw56kzHlgYuEEJR8mefFiiyR3u96498+zWPsLeh1WKvgIReoNE+U7gG8bCUdvsrJ0JRmev0Ky6n2O0g==",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"@vue/compiler-core": "3.2.38",
 				"@vue/shared": "3.2.38"
@@ -16002,36 +16110,62 @@
 				"@vue/shared": {
 					"version": "3.2.38",
 					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
 		"@vue/compiler-sfc": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.38.tgz",
-			"integrity": "sha512-KZjrW32KloMYtTcHAFuw3CqsyWc5X6seb8KbkANSWt3Cz9p2qA8c1GJpSkksFP9ABb6an0FLCFl46ZFXx3kKpg==",
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.9.tgz",
+			"integrity": "sha512-wy0CNc8z4ihoDzjASCOCsQuzW0A/HP27+0MDSSICMjVIFzk/rFViezkR3dzH+miS2NDEz8ywMdbjO5ylhOLI2A==",
 			"requires": {
-				"@babel/parser": "^7.16.4",
-				"@vue/compiler-core": "3.2.38",
-				"@vue/compiler-dom": "3.2.38",
-				"@vue/compiler-ssr": "3.2.38",
-				"@vue/reactivity-transform": "3.2.38",
-				"@vue/shared": "3.2.38",
+				"@babel/parser": "^7.23.3",
+				"@vue/compiler-core": "3.3.9",
+				"@vue/compiler-dom": "3.3.9",
+				"@vue/compiler-ssr": "3.3.9",
+				"@vue/reactivity-transform": "3.3.9",
+				"@vue/shared": "3.3.9",
 				"estree-walker": "^2.0.2",
-				"magic-string": "^0.25.7",
-				"postcss": "^8.1.10",
-				"source-map": "^0.6.1"
+				"magic-string": "^0.30.5",
+				"postcss": "^8.4.31",
+				"source-map-js": "^1.0.2"
 			},
 			"dependencies": {
-				"@vue/shared": {
-					"version": "3.2.38",
-					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+				"@vue/compiler-core": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
+					"integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
+					"requires": {
+						"@babel/parser": "^7.23.3",
+						"@vue/shared": "3.3.9",
+						"estree-walker": "^2.0.2",
+						"source-map-js": "^1.0.2"
+					}
 				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				"@vue/compiler-dom": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz",
+					"integrity": "sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==",
+					"requires": {
+						"@vue/compiler-core": "3.3.9",
+						"@vue/shared": "3.3.9"
+					}
+				},
+				"@vue/compiler-ssr": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.9.tgz",
+					"integrity": "sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==",
+					"requires": {
+						"@vue/compiler-dom": "3.3.9",
+						"@vue/shared": "3.3.9"
+					}
+				},
+				"@vue/shared": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+					"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
 				}
 			}
 		},
@@ -16039,6 +16173,8 @@
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.38.tgz",
 			"integrity": "sha512-bm9jOeyv1H3UskNm4S6IfueKjUNFmi2kRweFIGnqaGkkRePjwEcfCVqyS3roe7HvF4ugsEkhf4+kIvDhip6XzQ==",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"@vue/compiler-dom": "3.2.38",
 				"@vue/shared": "3.2.38"
@@ -16047,7 +16183,9 @@
 				"@vue/shared": {
 					"version": "3.2.38",
 					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -16125,63 +16263,81 @@
 				}
 			}
 		},
-		"@vue/reactivity-transform": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.38.tgz",
-			"integrity": "sha512-3SD3Jmi1yXrDwiNJqQ6fs1x61WsDLqVk4NyKVz78mkaIRh6d3IqtRnptgRfXn+Fzf+m6B1KxBYWq1APj6h4qeA==",
+		"@vue/reactivity": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.9.tgz",
+			"integrity": "sha512-VmpIqlNp+aYDg2X0xQhJqHx9YguOmz2UxuUJDckBdQCNkipJvfk9yA75woLWElCa0Jtyec3lAAt49GO0izsphw==",
 			"requires": {
-				"@babel/parser": "^7.16.4",
-				"@vue/compiler-core": "3.2.38",
-				"@vue/shared": "3.2.38",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.25.7"
+				"@vue/shared": "3.3.9"
 			},
 			"dependencies": {
 				"@vue/shared": {
-					"version": "3.2.38",
-					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+					"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
+				}
+			}
+		},
+		"@vue/reactivity-transform": {
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.9.tgz",
+			"integrity": "sha512-HnUFm7Ry6dFa4Lp63DAxTixUp8opMtQr6RxQCpDI1vlh12rkGIeYqMvJtK+IKyEfEOa2I9oCkD1mmsPdaGpdVg==",
+			"requires": {
+				"@babel/parser": "^7.23.3",
+				"@vue/compiler-core": "3.3.9",
+				"@vue/shared": "3.3.9",
+				"estree-walker": "^2.0.2",
+				"magic-string": "^0.30.5"
+			},
+			"dependencies": {
+				"@vue/compiler-core": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
+					"integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
+					"requires": {
+						"@babel/parser": "^7.23.3",
+						"@vue/shared": "3.3.9",
+						"estree-walker": "^2.0.2",
+						"source-map-js": "^1.0.2"
+					}
+				},
+				"@vue/shared": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+					"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
 				}
 			}
 		},
 		"@vue/runtime-core": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.38.tgz",
-			"integrity": "sha512-kk0qiSiXUU/IKxZw31824rxmFzrLr3TL6ZcbrxWTKivadoKupdlzbQM4SlGo4MU6Zzrqv4fzyUasTU1jDoEnzg==",
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.9.tgz",
+			"integrity": "sha512-xxaG9KvPm3GTRuM4ZyU8Tc+pMVzcu6eeoSRQJ9IE7NmCcClW6z4B3Ij6L4EDl80sxe/arTtQ6YmgiO4UZqRc+w==",
 			"requires": {
-				"@vue/reactivity": "3.2.38",
-				"@vue/shared": "3.2.38"
+				"@vue/reactivity": "3.3.9",
+				"@vue/shared": "3.3.9"
 			},
 			"dependencies": {
-				"@vue/reactivity": {
-					"version": "3.2.38",
-					"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.38.tgz",
-					"integrity": "sha512-6L4myYcH9HG2M25co7/BSo0skKFHpAN8PhkNPM4xRVkyGl1K5M3Jx4rp5bsYhvYze2K4+l+pioN4e6ZwFLUVtw==",
-					"requires": {
-						"@vue/shared": "3.2.38"
-					}
-				},
 				"@vue/shared": {
-					"version": "3.2.38",
-					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+					"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
 				}
 			}
 		},
 		"@vue/runtime-dom": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.38.tgz",
-			"integrity": "sha512-4PKAb/ck2TjxdMSzMsnHViOrrwpudk4/A56uZjhzvusoEU9xqa5dygksbzYepdZeB5NqtRw5fRhWIiQlRVK45A==",
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.9.tgz",
+			"integrity": "sha512-e7LIfcxYSWbV6BK1wQv9qJyxprC75EvSqF/kQKe6bdZEDNValzeRXEVgiX7AHI6hZ59HA4h7WT5CGvm69vzJTQ==",
 			"requires": {
-				"@vue/runtime-core": "3.2.38",
-				"@vue/shared": "3.2.38",
-				"csstype": "^2.6.8"
+				"@vue/runtime-core": "3.3.9",
+				"@vue/shared": "3.3.9",
+				"csstype": "^3.1.2"
 			},
 			"dependencies": {
 				"@vue/shared": {
-					"version": "3.2.38",
-					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+					"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
 				}
 			}
 		},
@@ -16189,6 +16345,8 @@
 			"version": "3.2.38",
 			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.38.tgz",
 			"integrity": "sha512-pg+JanpbOZ5kEfOZzO2bt02YHd+ELhYP8zPeLU1H0e7lg079NtuuSB8fjLdn58c4Ou8UQ6C1/P+528nXnLPAhA==",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"@vue/compiler-ssr": "3.2.38",
 				"@vue/shared": "3.2.38"
@@ -16197,7 +16355,9 @@
 				"@vue/shared": {
 					"version": "3.2.38",
 					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==",
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -17273,9 +17433,9 @@
 			}
 		},
 		"csstype": {
-			"version": "2.6.20",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-			"integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
+			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
 		},
 		"cypress": {
 			"version": "13.5.1",
@@ -21661,11 +21821,11 @@
 			}
 		},
 		"magic-string": {
-			"version": "0.25.9",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+			"version": "0.30.5",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
 			"requires": {
-				"sourcemap-codec": "^1.4.8"
+				"@jridgewell/sourcemap-codec": "^1.4.15"
 			}
 		},
 		"make-dir": {
@@ -22972,11 +23132,6 @@
 				}
 			}
 		},
-		"sourcemap-codec": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-		},
 		"spdx-correct": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -23978,7 +24133,7 @@
 			"version": "4.7.4",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
 			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-			"dev": true
+			"devOptional": true
 		},
 		"unbox-primitive": {
 			"version": "1.0.2",
@@ -24117,21 +24272,59 @@
 			"dev": true
 		},
 		"vue": {
-			"version": "3.2.38",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.2.38.tgz",
-			"integrity": "sha512-hHrScEFSmDAWL0cwO4B6WO7D3sALZPbfuThDsGBebthrNlDxdJZpGR3WB87VbjpPh96mep1+KzukYEhpHDFa8Q==",
+			"version": "3.3.9",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.3.9.tgz",
+			"integrity": "sha512-sy5sLCTR8m6tvUk1/ijri3Yqzgpdsmxgj6n6yl7GXXCXqVbmW2RCXe9atE4cEI6Iv7L89v5f35fZRRr5dChP9w==",
 			"requires": {
-				"@vue/compiler-dom": "3.2.38",
-				"@vue/compiler-sfc": "3.2.38",
-				"@vue/runtime-dom": "3.2.38",
-				"@vue/server-renderer": "3.2.38",
-				"@vue/shared": "3.2.38"
+				"@vue/compiler-dom": "3.3.9",
+				"@vue/compiler-sfc": "3.3.9",
+				"@vue/runtime-dom": "3.3.9",
+				"@vue/server-renderer": "3.3.9",
+				"@vue/shared": "3.3.9"
 			},
 			"dependencies": {
+				"@vue/compiler-core": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
+					"integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
+					"requires": {
+						"@babel/parser": "^7.23.3",
+						"@vue/shared": "3.3.9",
+						"estree-walker": "^2.0.2",
+						"source-map-js": "^1.0.2"
+					}
+				},
+				"@vue/compiler-dom": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz",
+					"integrity": "sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==",
+					"requires": {
+						"@vue/compiler-core": "3.3.9",
+						"@vue/shared": "3.3.9"
+					}
+				},
+				"@vue/compiler-ssr": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.9.tgz",
+					"integrity": "sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==",
+					"requires": {
+						"@vue/compiler-dom": "3.3.9",
+						"@vue/shared": "3.3.9"
+					}
+				},
+				"@vue/server-renderer": {
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.9.tgz",
+					"integrity": "sha512-w0zT/s5l3Oa3ZjtLW88eO4uV6AQFqU8X5GOgzq7SkQQu6vVr+8tfm+OI2kDBplS/W/XgCBuFXiPw6T5EdwXP0A==",
+					"requires": {
+						"@vue/compiler-ssr": "3.3.9",
+						"@vue/shared": "3.3.9"
+					}
+				},
 				"@vue/shared": {
-					"version": "3.2.38",
-					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.38.tgz",
-					"integrity": "sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg=="
+					"version": "3.3.9",
+					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
+					"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA=="
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@wmde/wikit-tokens": "^3.0.0-alpha.12",
 		"@wmde/wikit-vue-components": "^3.0.0-alpha.12",
 		"jest-environment-jsdom": "^29.7.0",
-		"vue": "^3.2.38",
+		"vue": "3.3.9",
 		"vuex": "^4.0.2"
 	},
 	"devDependencies": {

--- a/tests/unit/components/ItemLookup.test.ts
+++ b/tests/unit/components/ItemLookup.test.ts
@@ -9,7 +9,8 @@ jest.mock( 'lodash/debounce', () => jest.fn( ( fn ) => fn ) );
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function createLookup( propsOverrides: any = {} ): VueWrapper<any> {
-	return mount( ItemLookup, {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	return mount( ItemLookup as any, {
 		props: {
 			label: 'some label',
 			placeholder: 'some placeholder',


### PR DESCRIPTION
This follows the upgrade of the Vue version shipped with MediaWiki in I0b3b6adf (commit ed6f7b2). The goal is to have those two versions always exactly in sync.

Created with:
`npm install vue@3.3.9 --save-exact`

Bug: T352388