### PR TITLE
Update eslint-related-dependencies and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ npm run cypress:open
 You can see which dependencies have new releases by first making sure your local dependencies are up-to-date by executing `npm ci` and then running `npm outdated`.
 The following dependencies should be ignored:
 
+- @namics/stylelint-bem - version 10 drops support for node < 18.12, which we still need for CI
 - Wikit (i.e. `@wmde/wikit-tokens` and `@wmde/wikit-vue-components`):
   we’re using a newer pre-release version and don’t want to downgrade to the latest full release.
 - Vue and Vuex:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2269,16 +2269,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.1.tgz",
-			"integrity": "sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.18.1.tgz",
+			"integrity": "sha512-nISDRYnnIpk7VCFrGcu1rnZfM1Dh9LRHnfgdkjcbi/l7g16VYRri3TjXi9Ir4lOZSw5N/gnV/3H7jIPQ8Q4daA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.13.1",
-				"@typescript-eslint/type-utils": "6.13.1",
-				"@typescript-eslint/utils": "6.13.1",
-				"@typescript-eslint/visitor-keys": "6.13.1",
+				"@typescript-eslint/scope-manager": "6.18.1",
+				"@typescript-eslint/type-utils": "6.18.1",
+				"@typescript-eslint/utils": "6.18.1",
+				"@typescript-eslint/visitor-keys": "6.18.1",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -2319,15 +2319,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.1.tgz",
-			"integrity": "sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.18.1.tgz",
+			"integrity": "sha512-zct/MdJnVaRRNy9e84XnVtRv9Vf91/qqe+hZJtKanjojud4wAVy/7lXxJmMyX6X6J+xc6c//YEWvpeif8cAhWA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "6.13.1",
-				"@typescript-eslint/types": "6.13.1",
-				"@typescript-eslint/typescript-estree": "6.13.1",
-				"@typescript-eslint/visitor-keys": "6.13.1",
+				"@typescript-eslint/scope-manager": "6.18.1",
+				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/typescript-estree": "6.18.1",
+				"@typescript-eslint/visitor-keys": "6.18.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2347,13 +2347,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.1.tgz",
-			"integrity": "sha512-BW0kJ7ceiKi56GbT2KKzZzN+nDxzQK2DS6x0PiSMPjciPgd/JRQGMibyaN2cPt2cAvuoH0oNvn2fwonHI+4QUQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.18.1.tgz",
+			"integrity": "sha512-BgdBwXPFmZzaZUuw6wKiHKIovms97a7eTImjkXCZE04TGHysG+0hDQPmygyvgtkoB/aOQwSM/nWv3LzrOIQOBw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.13.1",
-				"@typescript-eslint/visitor-keys": "6.13.1"
+				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/visitor-keys": "6.18.1"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2364,13 +2364,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.1.tgz",
-			"integrity": "sha512-A2qPlgpxx2v//3meMqQyB1qqTg1h1dJvzca7TugM3Yc2USDY+fsRBiojAEo92HO7f5hW5mjAUF6qobOPzlBCBQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.18.1.tgz",
+			"integrity": "sha512-wyOSKhuzHeU/5pcRDP2G2Ndci+4g653V43gXTpt4nbyoIOAASkGDA9JIAgbQCdCkcr1MvpSYWzxTz0olCn8+/Q==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.13.1",
-				"@typescript-eslint/utils": "6.13.1",
+				"@typescript-eslint/typescript-estree": "6.18.1",
+				"@typescript-eslint/utils": "6.18.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2391,9 +2391,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.1.tgz",
-			"integrity": "sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.18.1.tgz",
+			"integrity": "sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2404,16 +2404,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.1.tgz",
-			"integrity": "sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.18.1.tgz",
+			"integrity": "sha512-fv9B94UAhywPRhUeeV/v+3SBDvcPiLxRZJw/xZeeGgRLQZ6rLMG+8krrJUyIf6s1ecWTzlsbp0rlw7n9sjufHA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.13.1",
-				"@typescript-eslint/visitor-keys": "6.13.1",
+				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/visitor-keys": "6.18.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
 				"semver": "^7.5.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2428,6 +2429,30 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -2446,17 +2471,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.1.tgz",
-			"integrity": "sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.18.1.tgz",
+			"integrity": "sha512-zZmTuVZvD1wpoceHvoQpOiewmWu3uP9FuTWo8vqpy2ffsmfCE8mklRPi+vmnIYAIk9t/4kOThri2QCDgor+OpQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.13.1",
-				"@typescript-eslint/types": "6.13.1",
-				"@typescript-eslint/typescript-estree": "6.13.1",
+				"@typescript-eslint/scope-manager": "6.18.1",
+				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/typescript-estree": "6.18.1",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -2486,12 +2511,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.1.tgz",
-			"integrity": "sha512-NDhQUy2tg6XGNBGDRm1XybOHSia8mcXmlbKWoQP+nm1BIIMxa55shyJfZkHpEBN62KNPLrocSM2PdPcaLgDKMQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.18.1.tgz",
+			"integrity": "sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.13.1",
+				"@typescript-eslint/types": "6.18.1",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -15879,16 +15904,16 @@
 			}
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.13.1.tgz",
-			"integrity": "sha512-5bQDGkXaxD46bPvQt08BUz9YSaO4S0fB1LB5JHQuXTfkGPI3+UUeS387C/e9jRie5GqT8u5kFTrMvAjtX4O5kA==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.18.1.tgz",
+			"integrity": "sha512-nISDRYnnIpk7VCFrGcu1rnZfM1Dh9LRHnfgdkjcbi/l7g16VYRri3TjXi9Ir4lOZSw5N/gnV/3H7jIPQ8Q4daA==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/regexpp": "^4.5.1",
-				"@typescript-eslint/scope-manager": "6.13.1",
-				"@typescript-eslint/type-utils": "6.13.1",
-				"@typescript-eslint/utils": "6.13.1",
-				"@typescript-eslint/visitor-keys": "6.13.1",
+				"@typescript-eslint/scope-manager": "6.18.1",
+				"@typescript-eslint/type-utils": "6.18.1",
+				"@typescript-eslint/utils": "6.18.1",
+				"@typescript-eslint/visitor-keys": "6.18.1",
 				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.2.4",
@@ -15909,61 +15934,80 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.1.tgz",
-			"integrity": "sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.18.1.tgz",
+			"integrity": "sha512-zct/MdJnVaRRNy9e84XnVtRv9Vf91/qqe+hZJtKanjojud4wAVy/7lXxJmMyX6X6J+xc6c//YEWvpeif8cAhWA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "6.13.1",
-				"@typescript-eslint/types": "6.13.1",
-				"@typescript-eslint/typescript-estree": "6.13.1",
-				"@typescript-eslint/visitor-keys": "6.13.1",
+				"@typescript-eslint/scope-manager": "6.18.1",
+				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/typescript-estree": "6.18.1",
+				"@typescript-eslint/visitor-keys": "6.18.1",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.1.tgz",
-			"integrity": "sha512-BW0kJ7ceiKi56GbT2KKzZzN+nDxzQK2DS6x0PiSMPjciPgd/JRQGMibyaN2cPt2cAvuoH0oNvn2fwonHI+4QUQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.18.1.tgz",
+			"integrity": "sha512-BgdBwXPFmZzaZUuw6wKiHKIovms97a7eTImjkXCZE04TGHysG+0hDQPmygyvgtkoB/aOQwSM/nWv3LzrOIQOBw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "6.13.1",
-				"@typescript-eslint/visitor-keys": "6.13.1"
+				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/visitor-keys": "6.18.1"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.1.tgz",
-			"integrity": "sha512-A2qPlgpxx2v//3meMqQyB1qqTg1h1dJvzca7TugM3Yc2USDY+fsRBiojAEo92HO7f5hW5mjAUF6qobOPzlBCBQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.18.1.tgz",
+			"integrity": "sha512-wyOSKhuzHeU/5pcRDP2G2Ndci+4g653V43gXTpt4nbyoIOAASkGDA9JIAgbQCdCkcr1MvpSYWzxTz0olCn8+/Q==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "6.13.1",
-				"@typescript-eslint/utils": "6.13.1",
+				"@typescript-eslint/typescript-estree": "6.18.1",
+				"@typescript-eslint/utils": "6.18.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.1.tgz",
-			"integrity": "sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.18.1.tgz",
+			"integrity": "sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.1.tgz",
-			"integrity": "sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.18.1.tgz",
+			"integrity": "sha512-fv9B94UAhywPRhUeeV/v+3SBDvcPiLxRZJw/xZeeGgRLQZ6rLMG+8krrJUyIf6s1ecWTzlsbp0rlw7n9sjufHA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "6.13.1",
-				"@typescript-eslint/visitor-keys": "6.13.1",
+				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/visitor-keys": "6.18.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
 				"semver": "^7.5.4",
 				"ts-api-utils": "^1.0.1"
 			},
 			"dependencies": {
+				"brace-expansion": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+					"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "9.0.3",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+					"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^2.0.1"
+					}
+				},
 				"semver": {
 					"version": "7.5.4",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -15976,17 +16020,17 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.1.tgz",
-			"integrity": "sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.18.1.tgz",
+			"integrity": "sha512-zZmTuVZvD1wpoceHvoQpOiewmWu3uP9FuTWo8vqpy2ffsmfCE8mklRPi+vmnIYAIk9t/4kOThri2QCDgor+OpQ==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.13.1",
-				"@typescript-eslint/types": "6.13.1",
-				"@typescript-eslint/typescript-estree": "6.13.1",
+				"@typescript-eslint/scope-manager": "6.18.1",
+				"@typescript-eslint/types": "6.18.1",
+				"@typescript-eslint/typescript-estree": "6.18.1",
 				"semver": "^7.5.4"
 			},
 			"dependencies": {
@@ -16002,12 +16046,12 @@
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.1.tgz",
-			"integrity": "sha512-NDhQUy2tg6XGNBGDRm1XybOHSia8mcXmlbKWoQP+nm1BIIMxa55shyJfZkHpEBN62KNPLrocSM2PdPcaLgDKMQ==",
+			"version": "6.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.18.1.tgz",
+			"integrity": "sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "6.13.1",
+				"@typescript-eslint/types": "6.18.1",
 				"eslint-visitor-keys": "^3.4.1"
 			}
 		},


### PR DESCRIPTION
Bump versions of @typescript/eslint-plugin and
@typecsript-eslint/parser. Add a note to the README that updates to stylelint-bem past v10 are not possible with current CI setup.

Bug: T354166