### PR TITLE
Remove custom Jest config hiding console warnings

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,9 +9,6 @@ module.exports = {
 		'^@/(.*)$': '<rootDir>/src/$1',
 		'\\.css$': '<rootDir>/tests/mocks/styleMock.js',
 	},
-	setupFiles: [
-		'./jest.overrides.js',
-	],
 	testEnvironment: 'jsdom',
 	testEnvironmentOptions: {
 		customExportConditions: [ 'node', 'node-addons' ],

--- a/jest.overrides.js
+++ b/jest.overrides.js
@@ -1,6 +1,0 @@
-( function () {
-	// eslint-disable-next-line no-console
-	console.warn = function () {
-		// ignore @vue/compat warnings
-	};
-}() );


### PR DESCRIPTION
This should no longer be needed, we’re not using @vue/compat anymore.

Bug: T355168

----

Draft because this actually shows quite a few other warnings. In theory, those don’t cause the tests to fail, but I think we should still fix them before merging this, otherwise the test output will become quite annoying.