### PR TITLE
Fix redirecting to URL without temporary user

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
 	testEnvironment: 'jsdom',
 	testEnvironmentOptions: {
 		customExportConditions: [ 'node', 'node-addons' ],
+		url: 'https://wiki.example/',
 	},
 	testPathIgnorePatterns: [ '<rootDir>/cypress/' ],
 	transform: {

--- a/src/@types/mediawiki.ts
+++ b/src/@types/mediawiki.ts
@@ -20,6 +20,7 @@ interface MwConfig {
 
 export type MwTrack = ( topic: `${'timing' | 'counter'}.${string}`, data?: object | number | string ) => void;
 
+/** Return a URL for the given page name and params. Note that the returned URL may be relative! */
 export type MwUtilGetUrl = ( pageName: string|null, params?: Record<string, unknown> ) => string;
 
 export interface MediaWiki {

--- a/src/data-access/MwApiLexemeCreator.ts
+++ b/src/data-access/MwApiLexemeCreator.ts
@@ -77,10 +77,11 @@ export default class MwApiLexemeCreator implements LexemeCreator {
 			} );
 
 		const entityResponse = response as WbEditEntityResponse;
+		const base = window.location.href;
 		if ( entityResponse.tempuserredirect ) {
-			return new URL( entityResponse.tempuserredirect );
+			return new URL( entityResponse.tempuserredirect, base );
 		}
-		return new URL( this.getUrl( `Special:EntityPage/${entityResponse.entity.id}` ) );
+		return new URL( this.getUrl( `Special:EntityPage/${entityResponse.entity.id}` ), base );
 	}
 
 }

--- a/tests/unit/data-access/MwApiLexemeCreator.test.ts
+++ b/tests/unit/data-access/MwApiLexemeCreator.test.ts
@@ -13,7 +13,8 @@ function mockRejectedDeferred( ...args: unknown[] ): unknown {
 }
 
 function mwGetUrl( pageName: string | null ) {
-	return `https://wiki.example/${pageName}`;
+	// relative URL (T358754), relative to testEnvironmentOptions.url in jest.config.js
+	return `/${pageName}`;
 }
 
 describe( 'MwApiLexemeCreator', () => {


### PR DESCRIPTION
`mw.util.getUrl()` can return a relative URL, which is illegal to pass directly into `new URL()` unless you also specify the base. Do that.

Directly using `window.location.href` as the base feels a bit ugly, but I don’t think injecting it as a separate parameter of the service would be nicer.

Bug: T358754