### PR TITLE
POC: Use Codex in NewLexemeForm

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
 				import DevLexemeCreator from './src/data-access/DevLexemeCreator';
 				import DevLangCodeRetriever from './src/data-access/DevLangCodeRetriever';
 				import LanguageItemSearcher from './src/data-access/LanguageItemSearcher';
+				import '@wikimedia/codex/dist/codex.style.css';
+				import '@wikimedia/codex-design-tokens/theme-wikimedia-ui.css';
 
 				const config = {
 					rootSelector: '#app',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wikimedia/codex": "^1.12.0",
+				"@wikimedia/codex-design-tokens": "^1.12.0",
 				"@wmde/wikibase-datamodel-types": "^0.2.0",
 				"@wmde/wikit-tokens": "^3.0.0-alpha.12",
 				"@wmde/wikit-vue-components": "^3.0.0-alpha.12",
@@ -1230,6 +1232,63 @@
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+			"integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.7"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.6.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+			"integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+			"dependencies": {
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.7"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+			"integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
+		},
+		"node_modules/@floating-ui/vue": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.0.6.tgz",
+			"integrity": "sha512-EdrOljjkpkkqZnrpqUcPoz9NvHxuTjUtSInh6GMv3+Mcy+giY2cE2pHh9rpacRcZ2eMSCxel9jWkWXTjLmY55w==",
+			"dependencies": {
+				"@floating-ui/dom": "^1.6.1",
+				"@floating-ui/utils": "^0.2.1",
+				"vue-demi": ">=0.13.0"
+			}
+		},
+		"node_modules/@floating-ui/vue/node_modules/vue-demi": {
+			"version": "0.14.10",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+			"integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+			"hasInstallScript": true,
+			"bin": {
+				"vue-demi-fix": "bin/vue-demi-fix.js",
+				"vue-demi-switch": "bin/vue-demi-switch.js"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"@vue/composition-api": "^1.0.0-rc.1",
+				"vue": "^3.0.0-0 || ^2.6.0"
+			},
+			"peerDependenciesMeta": {
+				"@vue/composition-api": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@hapi/hoek": {
@@ -3136,6 +3195,40 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@wikimedia/codex": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex/-/codex-1.12.0.tgz",
+			"integrity": "sha512-tqevWQFnVEunvElPQ+adHHU2WPfNVkDw0JAfQk90uVb1haoF1XwaXwpF4/mU5WqcX97FT+j7mHjXwgm19uwWLQ==",
+			"dependencies": {
+				"@floating-ui/vue": "1.0.6",
+				"@wikimedia/codex-icons": "1.12.0"
+			},
+			"engines": {
+				"node": ">=18",
+				"npm": ">=7.21.0"
+			},
+			"peerDependencies": {
+				"vue": "3.4.27"
+			}
+		},
+		"node_modules/@wikimedia/codex-design-tokens": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-design-tokens/-/codex-design-tokens-1.12.0.tgz",
+			"integrity": "sha512-b4hB4Dz16zs7bccU2Ezu3CVD82BH6xNIn7bV0EZsDBcY9s31wi1vNDB/4yqFLhY/SR5td18PgmceLPnqF33M5Q==",
+			"engines": {
+				"node": ">=18",
+				"npm": ">=7.21.0"
+			}
+		},
+		"node_modules/@wikimedia/codex-icons": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-icons/-/codex-icons-1.12.0.tgz",
+			"integrity": "sha512-HkTIA/cpCF9dNLaK6QaVuqFFEqeJHPafuGclzjei9oeNCUPox+vWOxuORUTjNlLJgh5MN1n9SuuEbifskvsXKA==",
+			"engines": {
+				"node": ">=18",
+				"npm": ">=7.21.0"
 			}
 		},
 		"node_modules/@wmde/eslint-config-wikimedia-typescript": {
@@ -15467,6 +15560,46 @@
 			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
 			"dev": true
 		},
+		"@floating-ui/core": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+			"integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+			"requires": {
+				"@floating-ui/utils": "^0.2.7"
+			}
+		},
+		"@floating-ui/dom": {
+			"version": "1.6.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+			"integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+			"requires": {
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.7"
+			}
+		},
+		"@floating-ui/utils": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+			"integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
+		},
+		"@floating-ui/vue": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.0.6.tgz",
+			"integrity": "sha512-EdrOljjkpkkqZnrpqUcPoz9NvHxuTjUtSInh6GMv3+Mcy+giY2cE2pHh9rpacRcZ2eMSCxel9jWkWXTjLmY55w==",
+			"requires": {
+				"@floating-ui/dom": "^1.6.1",
+				"@floating-ui/utils": "^0.2.1",
+				"vue-demi": ">=0.13.0"
+			},
+			"dependencies": {
+				"vue-demi": {
+					"version": "0.14.10",
+					"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+					"integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+					"requires": {}
+				}
+			}
+		},
 		"@hapi/hoek": {
 			"version": "9.3.0",
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -16883,6 +17016,25 @@
 				"source-map": "0.5.6",
 				"tsconfig": "^7.0.0"
 			}
+		},
+		"@wikimedia/codex": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex/-/codex-1.12.0.tgz",
+			"integrity": "sha512-tqevWQFnVEunvElPQ+adHHU2WPfNVkDw0JAfQk90uVb1haoF1XwaXwpF4/mU5WqcX97FT+j7mHjXwgm19uwWLQ==",
+			"requires": {
+				"@floating-ui/vue": "1.0.6",
+				"@wikimedia/codex-icons": "1.12.0"
+			}
+		},
+		"@wikimedia/codex-design-tokens": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-design-tokens/-/codex-design-tokens-1.12.0.tgz",
+			"integrity": "sha512-b4hB4Dz16zs7bccU2Ezu3CVD82BH6xNIn7bV0EZsDBcY9s31wi1vNDB/4yqFLhY/SR5td18PgmceLPnqF33M5Q=="
+		},
+		"@wikimedia/codex-icons": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-icons/-/codex-icons-1.12.0.tgz",
+			"integrity": "sha512-HkTIA/cpCF9dNLaK6QaVuqFFEqeJHPafuGclzjei9oeNCUPox+vWOxuORUTjNlLJgh5MN1n9SuuEbifskvsXKA=="
 		},
 		"@wmde/eslint-config-wikimedia-typescript": {
 			"version": "0.2.12",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
 		"node": ">=16"
 	},
 	"dependencies": {
+		"@wikimedia/codex": "^1.12.0",
+		"@wikimedia/codex-design-tokens": "^1.12.0",
 		"@wmde/wikibase-datamodel-types": "^0.2.0",
 		"@wmde/wikit-tokens": "^3.0.0-alpha.12",
 		"@wmde/wikit-vue-components": "^3.0.0-alpha.12",

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -6,7 +6,7 @@ import {
 	ref,
 } from 'vue';
 import { useStore } from 'vuex';
-import { Button as WikitButton } from '@wmde/wikit-vue-components';
+import { CdxButton } from '@wikimedia/codex';
 import { useConfig } from '@/plugins/ConfigPlugin/Config';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import LemmaInput from '@/components/LemmaInput.vue';
@@ -176,21 +176,22 @@ export default {
 			<span v-html="error" />
 		</error-message>
 		<div>
-			<wikit-button
+			<cdx-button
 				class="form-button-submit"
-				type="progressive"
-				variant="primary"
-				native-type="submit"
+				action="progressive"
+				weight="primary"
+				type="submit"
 				:disabled="submitting"
 			>
 				{{ submitButtonText }}
-			</wikit-button>
+			</cdx-button>
 		</div>
 	</form>
 </template>
 
 <style scoped lang="scss">
-@import '@wmde/wikit-tokens/variables';
+@import '@wmde/wikit-tokens/variables'; // TODO remove
+@import '@wikimedia/codex-design-tokens/theme-wikimedia-ui';
 @import '@wmde/wikit-vue-components/src/styles/mixins/Typography';
 
 .wbl-snl-form {
@@ -203,9 +204,9 @@ export default {
 
 	// Border
 	border-style: $border-style-base;
-	border-width: $border-width-thin;
+	border-width: $border-width-base;
 	border-radius: $border-radius-base;
-	border-color: $border-color-base-subtle;
+	border-color: $border-color-muted;
 }
 
 .wbl-snl-copyright {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ function getBuildConfig( isAppBuild: boolean ): BuildOptions {
 			formats: [ 'cjs' ],
 		},
 		rollupOptions: {
-			external: [ 'vue', 'vuex' ],
+			external: [ 'vue', 'vuex', '@wikimedia/codex' ],
 		},
 	};
 }


### PR DESCRIPTION
Using the Button component from Codex instead of Wikit is straightforward – we just need to rename a few props.

Using the variables is a bit more involved. Not only do we need replacement variables from Codex that aren’t always clear, but the small-text mixin used for the copyright notice also relies on the Wikit variables. So for now, this change just keeps importing the Wikit variables and lets Codex override them wherever they both use the same name.

Bug: T369505

----

Based on #746.