### PR TITLE
Use Codex tokens and custom spacing variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
 				import DevLexemeCreator from './src/data-access/DevLexemeCreator';
 				import DevLangCodeRetriever from './src/data-access/DevLangCodeRetriever';
 				import LanguageItemSearcher from './src/data-access/LanguageItemSearcher';
+				import '@wikimedia/codex/dist/codex.style.css';
+				import '@wikimedia/codex-design-tokens/theme-wikimedia-ui.css';
 
 				const config = {
 					rootSelector: '#app',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wikimedia/codex": "^1.12.0",
+				"@wikimedia/codex-design-tokens": "^1.12.0",
 				"@wmde/wikibase-datamodel-types": "^0.2.0",
 				"@wmde/wikit-tokens": "^3.0.0-alpha.12",
 				"@wmde/wikit-vue-components": "^3.0.0-alpha.12",
@@ -1230,6 +1232,63 @@
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+			"integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.7"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.6.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+			"integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+			"dependencies": {
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.7"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+			"integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
+		},
+		"node_modules/@floating-ui/vue": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.0.6.tgz",
+			"integrity": "sha512-EdrOljjkpkkqZnrpqUcPoz9NvHxuTjUtSInh6GMv3+Mcy+giY2cE2pHh9rpacRcZ2eMSCxel9jWkWXTjLmY55w==",
+			"dependencies": {
+				"@floating-ui/dom": "^1.6.1",
+				"@floating-ui/utils": "^0.2.1",
+				"vue-demi": ">=0.13.0"
+			}
+		},
+		"node_modules/@floating-ui/vue/node_modules/vue-demi": {
+			"version": "0.14.10",
+			"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+			"integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+			"hasInstallScript": true,
+			"bin": {
+				"vue-demi-fix": "bin/vue-demi-fix.js",
+				"vue-demi-switch": "bin/vue-demi-switch.js"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antfu"
+			},
+			"peerDependencies": {
+				"@vue/composition-api": "^1.0.0-rc.1",
+				"vue": "^3.0.0-0 || ^2.6.0"
+			},
+			"peerDependenciesMeta": {
+				"@vue/composition-api": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@hapi/hoek": {
@@ -3136,6 +3195,40 @@
 				"typescript": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@wikimedia/codex": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex/-/codex-1.12.0.tgz",
+			"integrity": "sha512-tqevWQFnVEunvElPQ+adHHU2WPfNVkDw0JAfQk90uVb1haoF1XwaXwpF4/mU5WqcX97FT+j7mHjXwgm19uwWLQ==",
+			"dependencies": {
+				"@floating-ui/vue": "1.0.6",
+				"@wikimedia/codex-icons": "1.12.0"
+			},
+			"engines": {
+				"node": ">=18",
+				"npm": ">=7.21.0"
+			},
+			"peerDependencies": {
+				"vue": "3.4.27"
+			}
+		},
+		"node_modules/@wikimedia/codex-design-tokens": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-design-tokens/-/codex-design-tokens-1.12.0.tgz",
+			"integrity": "sha512-b4hB4Dz16zs7bccU2Ezu3CVD82BH6xNIn7bV0EZsDBcY9s31wi1vNDB/4yqFLhY/SR5td18PgmceLPnqF33M5Q==",
+			"engines": {
+				"node": ">=18",
+				"npm": ">=7.21.0"
+			}
+		},
+		"node_modules/@wikimedia/codex-icons": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-icons/-/codex-icons-1.12.0.tgz",
+			"integrity": "sha512-HkTIA/cpCF9dNLaK6QaVuqFFEqeJHPafuGclzjei9oeNCUPox+vWOxuORUTjNlLJgh5MN1n9SuuEbifskvsXKA==",
+			"engines": {
+				"node": ">=18",
+				"npm": ">=7.21.0"
 			}
 		},
 		"node_modules/@wmde/eslint-config-wikimedia-typescript": {
@@ -15467,6 +15560,46 @@
 			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
 			"dev": true
 		},
+		"@floating-ui/core": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.7.tgz",
+			"integrity": "sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==",
+			"requires": {
+				"@floating-ui/utils": "^0.2.7"
+			}
+		},
+		"@floating-ui/dom": {
+			"version": "1.6.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.10.tgz",
+			"integrity": "sha512-fskgCFv8J8OamCmyun8MfjB1Olfn+uZKjOKZ0vhYF3gRmEUXcGOjxWL8bBr7i4kIuPZ2KD2S3EUIOxnjC8kl2A==",
+			"requires": {
+				"@floating-ui/core": "^1.6.0",
+				"@floating-ui/utils": "^0.2.7"
+			}
+		},
+		"@floating-ui/utils": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.7.tgz",
+			"integrity": "sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA=="
+		},
+		"@floating-ui/vue": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.0.6.tgz",
+			"integrity": "sha512-EdrOljjkpkkqZnrpqUcPoz9NvHxuTjUtSInh6GMv3+Mcy+giY2cE2pHh9rpacRcZ2eMSCxel9jWkWXTjLmY55w==",
+			"requires": {
+				"@floating-ui/dom": "^1.6.1",
+				"@floating-ui/utils": "^0.2.1",
+				"vue-demi": ">=0.13.0"
+			},
+			"dependencies": {
+				"vue-demi": {
+					"version": "0.14.10",
+					"resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+					"integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+					"requires": {}
+				}
+			}
+		},
 		"@hapi/hoek": {
 			"version": "9.3.0",
 			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -16883,6 +17016,25 @@
 				"source-map": "0.5.6",
 				"tsconfig": "^7.0.0"
 			}
+		},
+		"@wikimedia/codex": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex/-/codex-1.12.0.tgz",
+			"integrity": "sha512-tqevWQFnVEunvElPQ+adHHU2WPfNVkDw0JAfQk90uVb1haoF1XwaXwpF4/mU5WqcX97FT+j7mHjXwgm19uwWLQ==",
+			"requires": {
+				"@floating-ui/vue": "1.0.6",
+				"@wikimedia/codex-icons": "1.12.0"
+			}
+		},
+		"@wikimedia/codex-design-tokens": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-design-tokens/-/codex-design-tokens-1.12.0.tgz",
+			"integrity": "sha512-b4hB4Dz16zs7bccU2Ezu3CVD82BH6xNIn7bV0EZsDBcY9s31wi1vNDB/4yqFLhY/SR5td18PgmceLPnqF33M5Q=="
+		},
+		"@wikimedia/codex-icons": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-icons/-/codex-icons-1.12.0.tgz",
+			"integrity": "sha512-HkTIA/cpCF9dNLaK6QaVuqFFEqeJHPafuGclzjei9oeNCUPox+vWOxuORUTjNlLJgh5MN1n9SuuEbifskvsXKA=="
 		},
 		"@wmde/eslint-config-wikimedia-typescript": {
 			"version": "0.2.12",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
 		"node": ">=16"
 	},
 	"dependencies": {
+		"@wikimedia/codex": "^1.12.0",
+		"@wikimedia/codex-design-tokens": "^1.12.0",
 		"@wmde/wikibase-datamodel-types": "^0.2.0",
 		"@wmde/wikit-tokens": "^3.0.0-alpha.12",
 		"@wmde/wikit-vue-components": "^3.0.0-alpha.12",

--- a/src/components/AnonymousEditWarning.vue
+++ b/src/components/AnonymousEditWarning.vue
@@ -33,7 +33,9 @@ const warning = computed(
 </template>
 
 <style lang="scss" scoped>
+@import '@/styles/custom-variables.css';
+
 .wbl-snl-anonymous-edit-warning {
-	margin: 1rem 0;
+	margin: var( --dimension-layout-xsmall ) 0;
 }
 </style>

--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -79,11 +79,11 @@ export default {
 </template>
 
 <style lang="scss">
-@import '@wmde/wikit-tokens/variables';
+@import '@wikimedia/codex-design-tokens/theme-wikimedia-ui';
 
 /* stylelint-disable selector-class-pattern */
 .wbl-snl-language-lookup .wikit .wikit-Lookup__label-wrapper {
-	gap: $dimension-spacing-xsmall;
+	gap: $spacing-50;
 }
 /* stylelint-enable selector-class-pattern */
 

--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -71,11 +71,11 @@ export default {
 </template>
 
 <style lang="scss">
-@import '@wmde/wikit-tokens/variables';
+@import '@wikimedia/codex-design-tokens/theme-wikimedia-ui';
 
 /* stylelint-disable plugin/stylelint-bem-namics, selector-class-pattern */
 .wbl-snl-lemma-input.wikit .wikit-TextInput__label-wrapper {
-	gap: $dimension-spacing-xsmall;
+	gap: $spacing-50;
 }
 /* stylelint-enable plugin/stylelint-bem-namics, selector-class-pattern */
 </style>

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -73,10 +73,10 @@ export default {
 </template>
 
 <style lang="scss">
-@import '@wmde/wikit-tokens/variables';
+@import '@wikimedia/codex-design-tokens/theme-wikimedia-ui';
 /* stylelint-disable selector-class-pattern */
 .wbl-snl-lexical-category-lookup .wikit .wikit-Lookup__label-wrapper {
-	gap: $dimension-spacing-xsmall;
+	gap: $spacing-50;
 }
 /* stylelint-enable selector-class-pattern */
 

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -6,7 +6,7 @@ import {
 	ref,
 } from 'vue';
 import { useStore } from 'vuex';
-import { Button as WikitButton } from '@wmde/wikit-vue-components';
+import { CdxButton } from '@wikimedia/codex';
 import { useConfig } from '@/plugins/ConfigPlugin/Config';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import LemmaInput from '@/components/LemmaInput.vue';
@@ -176,21 +176,22 @@ export default {
 			<span v-html="error" />
 		</error-message>
 		<div>
-			<wikit-button
+			<cdx-button
 				class="form-button-submit"
-				type="progressive"
-				variant="primary"
-				native-type="submit"
+				action="progressive"
+				weight="primary"
+				type="submit"
 				:disabled="submitting"
 			>
 				{{ submitButtonText }}
-			</wikit-button>
+			</cdx-button>
 		</div>
 	</form>
 </template>
 
 <style scoped lang="scss">
-@import '@wmde/wikit-tokens/variables';
+@import '@wmde/wikit-tokens/variables'; // TODO remove
+@import '@wikimedia/codex-design-tokens/theme-wikimedia-ui';
 @import '@wmde/wikit-vue-components/src/styles/mixins/Typography';
 
 .wbl-snl-form {
@@ -203,9 +204,9 @@ export default {
 
 	// Border
 	border-style: $border-style-base;
-	border-width: $border-width-thin;
+	border-width: $border-width-base;
 	border-radius: $border-radius-base;
-	border-color: $border-color-base-subtle;
+	border-color: $border-color-muted;
 }
 
 .wbl-snl-copyright {

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -190,17 +190,16 @@ export default {
 </template>
 
 <style scoped lang="scss">
-@import '@wmde/wikit-tokens/variables'; // TODO remove
+@import '@/styles/custom-variables.css';
 @import '@wikimedia/codex-design-tokens/theme-wikimedia-ui';
-@import '@wmde/wikit-vue-components/src/styles/mixins/Typography';
 
 .wbl-snl-form {
 	& > * + * {
-		margin-top: $dimension-layout-xsmall;
+		margin-top: var( --dimension-layout-xsmall );
 	}
 
 	// Box model
-	padding: $dimension-layout-small;
+	padding: var( --dimension-layout-xsmall );
 
 	// Border
 	border-style: $border-style-base;
@@ -210,12 +209,12 @@ export default {
 }
 
 .wbl-snl-copyright {
-	@include small-text;
-
-	font-size: 0.8125rem;
-	font-style: italic;
-	font-synthesis: none;
-	margin-bottom: 0;
+	/* codex Body S */
+	font-family: $font-family-system-sans;
+	font-size: $font-size-small;
+	font-weight: $font-weight-normal;
+	line-height: $line-height-medium;
+	color: $color-base;
 }
 
 </style>

--- a/src/components/RequiredAsterisk.vue
+++ b/src/components/RequiredAsterisk.vue
@@ -21,18 +21,18 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-@import '@wmde/wikit-tokens/variables';
+@import '@wikimedia/codex-design-tokens/theme-wikimedia-ui';
 
 .wbl-snl-required-asterisk {
-	font-size: $font-size-xxlarge;
+	font-size: $font-size-xx-large;
 	line-height: 0;
 
 	&:not( :first-child ) {
-		margin-inline-start: $dimension-spacing-small;
+		margin-inline-start: $spacing-50;
 	}
 
 	&:not( :last-child ) {
-		margin-inline-end: $dimension-spacing-small;
+		margin-inline-end: $spacing-50;
 	}
 }
 </style>

--- a/src/components/SearchExisting.vue
+++ b/src/components/SearchExisting.vue
@@ -24,13 +24,19 @@ const searchMessage = computed( () => messages.get(
 </template>
 
 <style lang="scss" scoped>
-@import '@wmde/wikit-tokens/variables';
-@import '@wmde/wikit-vue-components/src/styles/mixins/Typography';
+@import '@/styles/custom-variables.css';
+@import '@wikimedia/codex-design-tokens/theme-wikimedia-ui';
 
 .wbl-snl-search-existing {
-	@include body;
+	/* font Codex Body */
+	font-family: $font-family-system-sans;
+	font-size: $font-size-medium;
+	font-weight: $font-weight-normal;
+	line-height: $line-height-medium;
+	color: $color-base;
 
-	margin-top: 1rem;
-	margin-bottom: 1rem;
+	/* margins */
+	margin-top: var( --dimension-layout-xsmall );
+	margin-bottom: var( --dimension-layout-xsmall );
 }
 </style>

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -128,17 +128,17 @@ export default {
 </template>
 
 <style lang="scss">
-@import '@wmde/wikit-tokens/variables';
+@import '@wikimedia/codex-design-tokens/theme-wikimedia-ui';
 
 .wbl-snl-spelling-variant-lookup {
 	/* stylelint-disable plugin/stylelint-bem-namics, selector-class-pattern */
 	&.wikit .wikit-Lookup__label-wrapper {
-		gap: $dimension-spacing-xsmall;
+		gap: $spacing-50;
 	}
 	/* stylelint-enable plugin/stylelint-bem-namics, selector-class-pattern */
 
 	&__help-link {
-		padding-bottom: $wikit-Label-padding-block-end;
+		padding-bottom: $spacing-50;
 		display: inline-block;
 	}
 }

--- a/src/styles/custom-variables.css
+++ b/src/styles/custom-variables.css
@@ -1,0 +1,4 @@
+* {
+	/* layout */
+	--dimension-layout-xsmall: 1rem;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ function getBuildConfig( isAppBuild: boolean ): BuildOptions {
 			formats: [ 'cjs' ],
 		},
 		rollupOptions: {
-			external: [ 'vue', 'vuex' ],
+			external: [ 'vue', 'vuex', '@wikimedia/codex' ],
 		},
 	};
 }


### PR DESCRIPTION
Migrate away from Wikit tokens to Codex SASS variables where they are available. In some cases we use custom CSS variables for values from Wikit whose Codex equivalents are missing.

Bug: T369510
Bug: T369508
Bug: T369509