### PR TITLE
Replace Wikit Message with Codex Message component

### DIFF
--- a/src/components/ErrorMessage.vue
+++ b/src/components/ErrorMessage.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import { Message as WikitMessage } from '@wmde/wikit-vue-components';
-
+import { CdxMessage } from '@wikimedia/codex';
 </script>
 
 <template>
-	<wikit-message type="error">
+	<cdx-message type="error">
 		<slot />
-	</wikit-message>
+	</cdx-message>
 </template>

--- a/src/components/WarningMessage.vue
+++ b/src/components/WarningMessage.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { Message as WikitMessage } from '@wmde/wikit-vue-components';
+import { CdxMessage } from '@wikimedia/codex';
 </script>
 
 <template>
-	<wikit-message type="warning">
+	<cdx-message type="warning">
 		<slot />
-	</wikit-message>
+	</cdx-message>
 </template>

--- a/tests/unit/components/__snapshots__/AnonymousEditWarning.test.ts.snap
+++ b/tests/unit/components/__snapshots__/AnonymousEditWarning.test.ts.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AnonymousEditWarning matches snapshot if anonymous 1`] = `"<div class="wikit wikit-Message wikit-Message--warning wbl-snl-anonymous-edit-warning"><span class="wikit-Message__content"><span class="wikit wikit-Icon wikit-Icon--large wikit-Icon--warning wikit-Message__icon"><svg class="wikit-Icon__svg" xmlns="http://www.w3.org/2000/svg" fill="none" aria-hidden="true" focusable="false" viewBox="0 0 16 16"><path fill="currentColor" d="M9.163 1.68234C9.06078 1.4381 8.89901 1.22746 8.69449 1.07231C8.48997 0.917151 8.25017 0.823144 7.99999 0.800049C7.75116 0.82453 7.51294 0.919178 7.30987 1.07425C7.10679 1.22933 6.94619 1.43922 6.84459 1.68234L0.672272 13.0631C0.0337565 14.2368 0.558251 15.2 1.82768 15.2H14.1723C15.4417 15.2 15.9662 14.2368 15.3277 13.0631L9.163 1.68234ZM8.76013 12.7717H7.23986V11.1528H8.76013V12.7717ZM8.76013 9.53394H7.23986V4.67728H8.76013V9.53394Z"></path></svg></span><span><!-- eslint-disable-next-line vue/no-v-html --><span>(wikibase-anonymouseditwarning, loginLink, createAccountLink)</span></span></span></div>"`;
+exports[`AnonymousEditWarning matches snapshot if anonymous 1`] = `
+"<transition-stub name="cdx-message" leaveactiveclass="" appear="false" persisted="false" css="true" class="wbl-snl-anonymous-edit-warning">
+  <div class="cdx-message cdx-message--block cdx-message--warning" aria-live="polite"><span class="cdx-icon cdx-icon--medium cdx-message__icon--vue"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><!--v-if--><g><path d="M11.53 2.3A1.85 1.85 0 0010 1.21 1.85 1.85 0 008.48 2.3L.36 16.36C-.48 17.81.21 19 1.88 19h16.24c1.67 0 2.36-1.19 1.52-2.64zM11 16H9v-2h2zm0-4H9V6h2z"></path></g></svg></span>
+    <div class="cdx-message__content">
+      <!-- eslint-disable-next-line vue/no-v-html --><span>(wikibase-anonymouseditwarning, loginLink, createAccountLink)</span>
+    </div>
+    <!--v-if-->
+  </div>
+</transition-stub>"
+`;
 
-exports[`AnonymousEditWarning uses alternative message if tempuser is enabled 1`] = `"<div class="wikit wikit-Message wikit-Message--warning wbl-snl-anonymous-edit-warning"><span class="wikit-Message__content"><span class="wikit wikit-Icon wikit-Icon--large wikit-Icon--warning wikit-Message__icon"><svg class="wikit-Icon__svg" xmlns="http://www.w3.org/2000/svg" fill="none" aria-hidden="true" focusable="false" viewBox="0 0 16 16"><path fill="currentColor" d="M9.163 1.68234C9.06078 1.4381 8.89901 1.22746 8.69449 1.07231C8.48997 0.917151 8.25017 0.823144 7.99999 0.800049C7.75116 0.82453 7.51294 0.919178 7.30987 1.07425C7.10679 1.22933 6.94619 1.43922 6.84459 1.68234L0.672272 13.0631C0.0337565 14.2368 0.558251 15.2 1.82768 15.2H14.1723C15.4417 15.2 15.9662 14.2368 15.3277 13.0631L9.163 1.68234ZM8.76013 12.7717H7.23986V11.1528H8.76013V12.7717ZM8.76013 9.53394H7.23986V4.67728H8.76013V9.53394Z"></path></svg></span><span><!-- eslint-disable-next-line vue/no-v-html --><span>(wikibase-anonymouseditnotificationtempuser, loginLink, createAccountLink)</span></span></span></div>"`;
+exports[`AnonymousEditWarning uses alternative message if tempuser is enabled 1`] = `
+"<transition-stub name="cdx-message" leaveactiveclass="" appear="false" persisted="false" css="true" class="wbl-snl-anonymous-edit-warning">
+  <div class="cdx-message cdx-message--block cdx-message--warning" aria-live="polite"><span class="cdx-icon cdx-icon--medium cdx-message__icon--vue"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><!--v-if--><g><path d="M11.53 2.3A1.85 1.85 0 0010 1.21 1.85 1.85 0 008.48 2.3L.36 16.36C-.48 17.81.21 19 1.88 19h16.24c1.67 0 2.36-1.19 1.52-2.64zM11 16H9v-2h2zm0-4H9V6h2z"></path></g></svg></span>
+    <div class="cdx-message__content">
+      <!-- eslint-disable-next-line vue/no-v-html --><span>(wikibase-anonymouseditnotificationtempuser, loginLink, createAccountLink)</span>
+    </div>
+    <!--v-if-->
+  </div>
+</transition-stub>"
+`;


### PR DESCRIPTION
Replace instances of Wikit's Message component in ErrorMessage and WarningMessage with the Codex equivalent.

Bug: T370055