### PR TITLE
Remove wikit link component

### DIFF
--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -2,7 +2,6 @@
 import { ref, computed } from 'vue';
 import escapeRegExp from 'lodash/escapeRegExp';
 import WikitLookup from './WikitLookup';
-import { Link as WikitLink } from '@wmde/wikit-vue-components';
 import RequiredAsterisk from '@/components/RequiredAsterisk.vue';
 import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 import { useLanguageCodesProvider } from '@/plugins/LanguageCodesProviderPlugin/LanguageCodesProvider';
@@ -121,7 +120,7 @@ export default {
 		<template #suffix>
 			<required-asterisk />
 			<span class="wbl-snl-spelling-variant-lookup__help-link">
-				<wikit-link :href="helpUrl" target="_blank">{{ helpLinkText }}</wikit-link>
+				<a :href="helpUrl" target="_blank">{{ helpLinkText }}</a>
 			</span>
 		</template>
 	</wikit-lookup>
@@ -136,10 +135,5 @@ export default {
 		gap: $dimension-spacing-xsmall;
 	}
 	/* stylelint-enable plugin/stylelint-bem-namics, selector-class-pattern */
-
-	&__help-link {
-		padding-bottom: $wikit-Label-padding-block-end;
-		display: inline-block;
-	}
 }
 </style>


### PR DESCRIPTION
Replaces the Wikit Link component with a plain link, which gets codex styling through the default stylesheet.

Bug: T370053