### PR TITLE
Fix unreliable input on SpellingVariantInput

### DIFF
--- a/tests/unit/components/SpellingVariantInput.test.ts
+++ b/tests/unit/components/SpellingVariantInput.test.ts
@@ -52,12 +52,9 @@ describe( 'SpellingVariantInput', () => {
 			const lookup = createLookup();
 
 			await lookup.find( 'input' ).setValue( 'en' );
-			await lookup.setProps( {
-				modelValue: 'English (en)',
-			} );
 
 			expect( lookup.find( 'div.cdx-text-input' ).get( 'input' ).element.value )
-				.toStrictEqual( 'English (en)' );
+				.toStrictEqual( 'en' );
 		} );
 
 		it( ':menuItems - returned suggestions are provided to Codex Lookup', async () => {


### PR DESCRIPTION
In the port from Wikit to Codex, the new implementation of `SpellingVariantInput` was working, but was dropping some inputs entered by users.

Remove the unused `search-input` attribute of the Codex Lookup component in `SpellingVariantInput` and wire the `input-value` property in the same way it has been connected in the `ItemLookup` implementation.

Bug: T379595