### PR TITLE
Remove unnecessary `onOptionSelected` call

### DIFF
--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -68,7 +68,6 @@ const onInput = ( inputValue: string ) => {
 	menuItems.value = wbLexemeTermLanguages.filter(
 		( lang ) => lang.label && regExp.test( lang.label ),
 	);
-	onOptionSelected( inputValue );
 };
 
 const selection = ref( null );

--- a/tests/unit/components/SpellingVariantInput.test.ts
+++ b/tests/unit/components/SpellingVariantInput.test.ts
@@ -140,29 +140,4 @@ describe( 'SpellingVariantInput', () => {
 		} );
 	} );
 
-	describe( '@events', () => {
-		it( '@update:modelValue - emits null when the input is changed', async () => {
-			const lookup = createLookup();
-
-			await setSearchInput( lookup, 'foo' );
-
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			expect( lookup.emitted( 'update:modelValue' )[ 0 ][ 0 ] ).toBe( undefined );
-		} );
-
-		it( '@update:modelValue - emits the value of the selected option', async () => {
-			const lookup = createLookup();
-			await setSearchInput( lookup, 'en' );
-
-			await lookup.findComponent( CdxLookup ).vm.$emit( 'update:selected', 'en' );
-
-			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-			// @ts-ignore
-			expect( lookup.emitted( 'update:modelValue' )[ 1 ][ 0 ] )
-				.toBe( 'en' );
-
-		} );
-	} );
-
 } );


### PR DESCRIPTION
The code for `SpellingVariantInput` was making an unnecessary extra call to `onOptionSelected` when `onInput` was called, to satisfy assertions in the unit test suite that are very involved with the internals of the component eventing logic. This worked okay for codex 1.14.0, but is incompatible with the behaviour changes introduced in Icd4b7ed1e34bf5b2d62f705fdd8c6f4e0cf088d1.

Remove the unnecessary call, and remove the unnecessarily detailed unit tests.

Bug: T379595