### PR TITLE
Move properties before nested selector to resolve deprecation warnings

### DIFF
--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -195,10 +195,6 @@ export default {
 @import '@wikimedia/codex-design-tokens/theme-wikimedia-ui';
 
 .wbl-snl-form {
-	& > * + * {
-		margin-top: var( --dimension-layout-xsmall );
-	}
-
 	// Box model
 	padding: var( --dimension-layout-small );
 
@@ -207,6 +203,10 @@ export default {
 	border-width: $border-width-base;
 	border-radius: $border-radius-base;
 	border-color: $border-color-muted;
+
+	& > * + * {
+		margin-top: var( --dimension-layout-xsmall );
+	}
 }
 
 .wbl-snl-copyright {


### PR DESCRIPTION
SASS has been emitting a deprecation warning because of a coming change in SASS behaviour:

https://sass-lang.com/documentation/breaking-changes/mixed-decls/

In `NewLexemeForm.vue` we were using the `&` parent selector before applying additional properties to the `.wbl-snl-form` element.

In this specific case, moving the parent selector after the property declarations has no effect on the semantics of the SASS or the generated CSS, and resolves the deprecation warning.

Bug: T372250