### PR TITLE
Remove unnecessary compatConfig flags

### DIFF
--- a/src/components/LanguageInput.vue
+++ b/src/components/LanguageInput.vue
@@ -61,14 +61,6 @@ const searchInputWrapper = useModelWrapper(
 );
 </script>
 
-<script lang="ts">
-export default {
-	compatConfig: {
-		MODE: 3,
-	},
-};
-</script>
-
 <template>
 	<div class="wbl-snl-language-lookup">
 		<item-lookup

--- a/src/components/LemmaInput.vue
+++ b/src/components/LemmaInput.vue
@@ -52,14 +52,6 @@ const error = computed( (): {
 } );
 </script>
 
-<script lang="ts">
-export default {
-	compatConfig: {
-		MODE: 3,
-	},
-};
-</script>
-
 <template>
 	<cdx-field
 		class="wbl-snl-lemma-input"

--- a/src/components/LexicalCategoryInput.vue
+++ b/src/components/LexicalCategoryInput.vue
@@ -40,14 +40,6 @@ const error = computed( () => {
 } );
 </script>
 
-<script lang="ts">
-export default {
-	compatConfig: {
-		MODE: 3,
-	},
-};
-</script>
-
 <template>
 	<div class="wbl-snl-lexical-category-lookup">
 		<item-lookup

--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -143,14 +143,6 @@ const onSubmit = async () => {
 
 </script>
 
-<script lang="ts">
-export default {
-	compatConfig: {
-		MODE: 3,
-	},
-};
-</script>
-
 <template>
 	<form class="wbl-snl-form">
 		<lemma-input

--- a/src/components/RequiredAsterisk.vue
+++ b/src/components/RequiredAsterisk.vue
@@ -4,14 +4,6 @@ import { useMessages } from '@/plugins/MessagesPlugin/Messages';
 const messages = useMessages();
 </script>
 
-<script lang="ts">
-export default {
-	compatConfig: {
-		MODE: 3,
-	},
-};
-</script>
-
 <template>
 	<span
 		class="wbl-snl-required-asterisk"

--- a/src/components/SpellingVariantInput.vue
+++ b/src/components/SpellingVariantInput.vue
@@ -112,14 +112,6 @@ const searchInputWrapper = useModelWrapper(
 );
 </script>
 
-<script lang="ts">
-export default {
-	compatConfig: {
-		MODE: 3,
-	},
-};
-</script>
-
 <template>
 	<cdx-field
 		class="wbl-snl-spelling-variant-lookup"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,15 +35,7 @@ export default defineConfig( {
 		},
 	},
 	plugins: [
-		vue( {
-			template: {
-				compilerOptions: {
-					compatConfig: {
-						MODE: 3,
-					},
-				},
-			},
-		} ),
+		vue(),
 		banner( '/*!/*@nomin*/' ),
 	],
 } );


### PR DESCRIPTION
Now that the migration to Vue 3 is complete, compatConfig is no longer needed and should be removed.

Bug: T355239