### PR TITLE
Update Vue, Codex and related dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
 			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wikimedia/codex": "^1.16.0",
-				"@wikimedia/codex-design-tokens": "^1.16.0",
+				"@wikimedia/codex": "^1.20.0",
+				"@wikimedia/codex-design-tokens": "^1.20.0",
 				"@wmde/wikibase-datamodel-types": "^0.2.0",
 				"jest-environment-jsdom": "^29.7.0",
-				"vue": "3.4.27",
-				"vuex": "4.0.2"
+				"vue": "^3.5.13",
+				"vuex": "^4.1.0"
 			},
 			"devDependencies": {
 				"@namics/stylelint-bem": "^10.1.0",
@@ -26,7 +26,7 @@
 				"@vitejs/plugin-vue": "^5.2.1",
 				"@vue/compiler-dom": "^3.5.13",
 				"@vue/eslint-config-typescript": "^13.0.0",
-				"@vue/server-renderer": "3.4.27",
+				"@vue/server-renderer": "^3.5.13",
 				"@vue/test-utils": "^2.4.6",
 				"@vue/vue3-jest": "^29.2.6",
 				"@wmde/eslint-config-wikimedia-typescript": "^0.2.12",
@@ -54,7 +54,7 @@
 				"typescript": "^5.6.3",
 				"vite": "^6.0.7",
 				"vite-plugin-banner": "^0.8.0",
-				"vue-tsc": "^2.1.6"
+				"vue-tsc": "^2.2.0"
 			},
 			"engines": {
 				"node": ">=16"
@@ -3303,38 +3303,42 @@
 			}
 		},
 		"node_modules/@volar/language-core": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.5.tgz",
-			"integrity": "sha512-F4tA0DCO5Q1F5mScHmca0umsi2ufKULAnMOVBfMsZdT4myhVl4WdKRwCaKcfOkIEuyrAVvtq1ESBdZ+rSyLVww==",
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
+			"integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@volar/source-map": "2.4.5"
+				"@volar/source-map": "2.4.11"
 			}
 		},
 		"node_modules/@volar/source-map": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.5.tgz",
-			"integrity": "sha512-varwD7RaKE2J/Z+Zu6j3mNNJbNT394qIxXwdvz/4ao/vxOfyClZpSDtLKkwWmecinkOVos5+PWkWraelfMLfpw==",
-			"dev": true
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
+			"integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@volar/typescript": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.5.tgz",
-			"integrity": "sha512-mcT1mHvLljAEtHviVcBuOyAwwMKz1ibXTi5uYtP/pf4XxoAzpdkQ+Br2IC0NPCvLCbjPZmbf3I0udndkfB1CDg==",
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.11.tgz",
+			"integrity": "sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@volar/language-core": "2.4.5",
+				"@volar/language-core": "2.4.11",
 				"path-browserify": "^1.0.1",
 				"vscode-uri": "^3.0.8"
 			}
 		},
 		"node_modules/@vue/compiler-core": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
-			"integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+			"integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
+			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.24.4",
-				"@vue/shared": "3.4.27",
+				"@babel/parser": "^7.25.3",
+				"@vue/shared": "3.5.13",
 				"entities": "^4.5.0",
 				"estree-walker": "^2.0.2",
 				"source-map-js": "^1.2.0"
@@ -3344,72 +3348,36 @@
 			"version": "3.5.13",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
 			"integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
-			"dev": true,
 			"dependencies": {
 				"@vue/compiler-core": "3.5.13",
 				"@vue/shared": "3.5.13"
 			}
 		},
-		"node_modules/@vue/compiler-dom/node_modules/@vue/compiler-core": {
+		"node_modules/@vue/compiler-sfc": {
 			"version": "3.5.13",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
-			"integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
-			"dev": true,
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+			"integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.25.3",
+				"@vue/compiler-core": "3.5.13",
+				"@vue/compiler-dom": "3.5.13",
+				"@vue/compiler-ssr": "3.5.13",
 				"@vue/shared": "3.5.13",
-				"entities": "^4.5.0",
 				"estree-walker": "^2.0.2",
+				"magic-string": "^0.30.11",
+				"postcss": "^8.4.48",
 				"source-map-js": "^1.2.0"
-			}
-		},
-		"node_modules/@vue/compiler-dom/node_modules/@vue/shared": {
-			"version": "3.5.13",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-			"integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
-			"dev": true
-		},
-		"node_modules/@vue/compiler-sfc": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
-			"integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
-			"dependencies": {
-				"@babel/parser": "^7.24.4",
-				"@vue/compiler-core": "3.4.27",
-				"@vue/compiler-dom": "3.4.27",
-				"@vue/compiler-ssr": "3.4.27",
-				"@vue/shared": "3.4.27",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.10",
-				"postcss": "^8.4.38",
-				"source-map-js": "^1.2.0"
-			}
-		},
-		"node_modules/@vue/compiler-sfc/node_modules/@vue/compiler-dom": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
-			"integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
-			"dependencies": {
-				"@vue/compiler-core": "3.4.27",
-				"@vue/shared": "3.4.27"
 			}
 		},
 		"node_modules/@vue/compiler-ssr": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
-			"integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+			"integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.4.27",
-				"@vue/shared": "3.4.27"
-			}
-		},
-		"node_modules/@vue/compiler-ssr/node_modules/@vue/compiler-dom": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
-			"integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
-			"dependencies": {
-				"@vue/compiler-core": "3.4.27",
-				"@vue/shared": "3.4.27"
+				"@vue/compiler-dom": "3.5.13",
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"node_modules/@vue/compiler-vue2": {
@@ -3417,6 +3385,7 @@
 			"resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
 			"integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"de-indent": "^1.0.2",
 				"he": "^1.2.0"
@@ -3452,16 +3421,17 @@
 			}
 		},
 		"node_modules/@vue/language-core": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.6.tgz",
-			"integrity": "sha512-MW569cSky9R/ooKMh6xa2g1D0AtRKbL56k83dzus/bx//RDJk24RHWkMzbAlXjMdDNyxAaagKPRquBIxkxlCkg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.0.tgz",
+			"integrity": "sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@volar/language-core": "~2.4.1",
-				"@vue/compiler-dom": "^3.4.0",
+				"@volar/language-core": "~2.4.11",
+				"@vue/compiler-dom": "^3.5.0",
 				"@vue/compiler-vue2": "^2.7.16",
-				"@vue/shared": "^3.4.0",
-				"computeds": "^0.0.1",
+				"@vue/shared": "^3.5.0",
+				"alien-signals": "^0.4.9",
 				"minimatch": "^9.0.3",
 				"muggle-string": "^0.4.1",
 				"path-browserify": "^1.0.1"
@@ -3480,6 +3450,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -3489,6 +3460,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
 			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -3500,48 +3472,54 @@
 			}
 		},
 		"node_modules/@vue/reactivity": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
-			"integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
+			"integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/shared": "3.4.27"
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"node_modules/@vue/runtime-core": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
-			"integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
+			"integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/reactivity": "3.4.27",
-				"@vue/shared": "3.4.27"
+				"@vue/reactivity": "3.5.13",
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"node_modules/@vue/runtime-dom": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
-			"integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
+			"integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/runtime-core": "3.4.27",
-				"@vue/shared": "3.4.27",
+				"@vue/reactivity": "3.5.13",
+				"@vue/runtime-core": "3.5.13",
+				"@vue/shared": "3.5.13",
 				"csstype": "^3.1.3"
 			}
 		},
 		"node_modules/@vue/server-renderer": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
-			"integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
+			"integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-ssr": "3.4.27",
-				"@vue/shared": "3.4.27"
+				"@vue/compiler-ssr": "3.5.13",
+				"@vue/shared": "3.5.13"
 			},
 			"peerDependencies": {
-				"vue": "3.4.27"
+				"vue": "3.5.13"
 			}
 		},
 		"node_modules/@vue/shared": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
-			"integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA=="
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+			"integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+			"license": "MIT"
 		},
 		"node_modules/@vue/test-utils": {
 			"version": "2.4.6",
@@ -3583,37 +3561,40 @@
 			}
 		},
 		"node_modules/@wikimedia/codex": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/@wikimedia/codex/-/codex-1.16.0.tgz",
-			"integrity": "sha512-dhic5AMcVcuDsNHv/HKKyOJG059BbyucfuWJutEWNhbmAsk/eixE2Jazvp9sOel+4H5sMjP4kppjKzGt66JdbA==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex/-/codex-1.20.0.tgz",
+			"integrity": "sha512-O97rzmVeI/lwldNhXOKRCqUgsQTVUS5xm4QQBSu/r7ldf5rjE4kmEC+DtWaqT2uXGzy69v+Yv+tgajZ1BJPZdw==",
+			"license": "GPL-2.0+",
 			"dependencies": {
 				"@floating-ui/vue": "1.0.6",
-				"@wikimedia/codex-icons": "1.16.0"
+				"@wikimedia/codex-icons": "1.20.0"
 			},
 			"engines": {
-				"node": ">=18",
-				"npm": ">=7.21.0"
+				"node": ">=20",
+				"npm": ">=10.8.1"
 			},
 			"peerDependencies": {
-				"vue": "3.4.27"
+				"vue": "^3.5.13"
 			}
 		},
 		"node_modules/@wikimedia/codex-design-tokens": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/@wikimedia/codex-design-tokens/-/codex-design-tokens-1.16.0.tgz",
-			"integrity": "sha512-/IjiyMVKbPxEMH+uJvMxIpJhOvjmo4jgOxw80kakBrnDV3aQl+bYhhtk5slbWMw/xatqkzgKsuBIBOFq7xLx1Q==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-design-tokens/-/codex-design-tokens-1.20.0.tgz",
+			"integrity": "sha512-3Z5nngMIaIdDClzMQO1FL8HmGcONWUbX8YgM/2nuBy3xuCns7UPp+oQi8+2+wqKd9HpLF+dxHY5+m23GE8LMuQ==",
+			"license": "GPL-2.0+",
 			"engines": {
-				"node": ">=18",
-				"npm": ">=7.21.0"
+				"node": ">=20",
+				"npm": ">=10.8.1"
 			}
 		},
 		"node_modules/@wikimedia/codex-icons": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/@wikimedia/codex-icons/-/codex-icons-1.16.0.tgz",
-			"integrity": "sha512-iMEJaETNwkFMG2VE0UNrS9Pv7JTrY184xLAd4FDPpy3icxPrVw/iDJ4tGTr1HrMVhC2JKApdLDRHyHtkMdZxNg==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-icons/-/codex-icons-1.20.0.tgz",
+			"integrity": "sha512-MAcSLU3fEKXJkHu7dB1eBWFWPTmEbVxHi8+BfKDDpQ7zAvrpq89PAlkKutbD6lmrx5Z8rd6b53ePvlPooYwEiQ==",
+			"license": "MIT",
 			"engines": {
-				"node": ">=18",
-				"npm": ">=7.21.0"
+				"node": ">=20",
+				"npm": ">=10.8.1"
 			}
 		},
 		"node_modules/@wmde/eslint-config-wikimedia-typescript": {
@@ -3733,6 +3714,13 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
+		},
+		"node_modules/alien-signals": {
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.4.14.tgz",
+			"integrity": "sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/ansi-colors": {
 			"version": "4.1.3",
@@ -4672,12 +4660,6 @@
 				"node": ">=4.0.0"
 			}
 		},
-		"node_modules/computeds": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
-			"integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
-			"dev": true
-		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4961,7 +4943,8 @@
 		"node_modules/csstype": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+			"license": "MIT"
 		},
 		"node_modules/cypress": {
 			"version": "13.15.0",
@@ -5168,7 +5151,8 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
 			"integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.0",
@@ -7818,6 +7802,7 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"he": "bin/he"
 			}
@@ -11389,9 +11374,10 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.30.11",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-			"integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+			"version": "0.30.17",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
@@ -11600,7 +11586,8 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
 			"integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/multimatch": {
 			"version": "5.0.0",
@@ -12030,7 +12017,8 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
 			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
@@ -14821,18 +14809,20 @@
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
 			"integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/vue": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
-			"integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
+			"integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
+			"license": "MIT",
 			"dependencies": {
-				"@vue/compiler-dom": "3.4.27",
-				"@vue/compiler-sfc": "3.4.27",
-				"@vue/runtime-dom": "3.4.27",
-				"@vue/server-renderer": "3.4.27",
-				"@vue/shared": "3.4.27"
+				"@vue/compiler-dom": "3.5.13",
+				"@vue/compiler-sfc": "3.5.13",
+				"@vue/runtime-dom": "3.5.13",
+				"@vue/server-renderer": "3.5.13",
+				"@vue/shared": "3.5.13"
 			},
 			"peerDependencies": {
 				"typescript": "*"
@@ -14886,14 +14876,14 @@
 			}
 		},
 		"node_modules/vue-tsc": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.1.6.tgz",
-			"integrity": "sha512-f98dyZp5FOukcYmbFpuSCJ4Z0vHSOSmxGttZJCsFeX0M4w/Rsq0s4uKXjcSRsZqsRgQa6z7SfuO+y0HVICE57Q==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.0.tgz",
+			"integrity": "sha512-gtmM1sUuJ8aSb0KoAFmK9yMxb8TxjewmxqTJ1aKphD5Cbu0rULFY6+UQT51zW7SpUcenfPUuflKyVwyx9Qdnxg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@volar/typescript": "~2.4.1",
-				"@vue/language-core": "2.1.6",
-				"semver": "^7.5.4"
+				"@volar/typescript": "~2.4.11",
+				"@vue/language-core": "2.2.0"
 			},
 			"bin": {
 				"vue-tsc": "bin/vue-tsc.js"
@@ -14902,39 +14892,16 @@
 				"typescript": ">=5.0.0"
 			}
 		},
-		"node_modules/vue-tsc/node_modules/semver": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/vue/node_modules/@vue/compiler-dom": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
-			"integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
-			"dependencies": {
-				"@vue/compiler-core": "3.4.27",
-				"@vue/shared": "3.4.27"
-			}
-		},
 		"node_modules/vuex": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.2.tgz",
-			"integrity": "sha512-M6r8uxELjZIK8kTKDGgZTYX/ahzblnzC4isU1tpmEuOIIKmV+TRdc+H4s8ds2NuZ7wpUTdGRzJRtoj+lI+pc0Q==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
+			"integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@vue/devtools-api": "^6.0.0-beta.11"
 			},
 			"peerDependencies": {
-				"vue": "^3.0.2"
+				"vue": "^3.2.0"
 			}
 		},
 		"node_modules/w3c-hr-time": {
@@ -17452,38 +17419,38 @@
 			"requires": {}
 		},
 		"@volar/language-core": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.5.tgz",
-			"integrity": "sha512-F4tA0DCO5Q1F5mScHmca0umsi2ufKULAnMOVBfMsZdT4myhVl4WdKRwCaKcfOkIEuyrAVvtq1ESBdZ+rSyLVww==",
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
+			"integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
 			"dev": true,
 			"requires": {
-				"@volar/source-map": "2.4.5"
+				"@volar/source-map": "2.4.11"
 			}
 		},
 		"@volar/source-map": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.5.tgz",
-			"integrity": "sha512-varwD7RaKE2J/Z+Zu6j3mNNJbNT394qIxXwdvz/4ao/vxOfyClZpSDtLKkwWmecinkOVos5+PWkWraelfMLfpw==",
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
+			"integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
 			"dev": true
 		},
 		"@volar/typescript": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.5.tgz",
-			"integrity": "sha512-mcT1mHvLljAEtHviVcBuOyAwwMKz1ibXTi5uYtP/pf4XxoAzpdkQ+Br2IC0NPCvLCbjPZmbf3I0udndkfB1CDg==",
+			"version": "2.4.11",
+			"resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.11.tgz",
+			"integrity": "sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==",
 			"dev": true,
 			"requires": {
-				"@volar/language-core": "2.4.5",
+				"@volar/language-core": "2.4.11",
 				"path-browserify": "^1.0.1",
 				"vscode-uri": "^3.0.8"
 			}
 		},
 		"@vue/compiler-core": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
-			"integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+			"integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
 			"requires": {
-				"@babel/parser": "^7.24.4",
-				"@vue/shared": "3.4.27",
+				"@babel/parser": "^7.25.3",
+				"@vue/shared": "3.5.13",
 				"entities": "^4.5.0",
 				"estree-walker": "^2.0.2",
 				"source-map-js": "^1.2.0"
@@ -17493,78 +17460,34 @@
 			"version": "3.5.13",
 			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
 			"integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
-			"dev": true,
 			"requires": {
 				"@vue/compiler-core": "3.5.13",
 				"@vue/shared": "3.5.13"
-			},
-			"dependencies": {
-				"@vue/compiler-core": {
-					"version": "3.5.13",
-					"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
-					"integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
-					"dev": true,
-					"requires": {
-						"@babel/parser": "^7.25.3",
-						"@vue/shared": "3.5.13",
-						"entities": "^4.5.0",
-						"estree-walker": "^2.0.2",
-						"source-map-js": "^1.2.0"
-					}
-				},
-				"@vue/shared": {
-					"version": "3.5.13",
-					"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-					"integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
-					"dev": true
-				}
 			}
 		},
 		"@vue/compiler-sfc": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
-			"integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
+			"integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
 			"requires": {
-				"@babel/parser": "^7.24.4",
-				"@vue/compiler-core": "3.4.27",
-				"@vue/compiler-dom": "3.4.27",
-				"@vue/compiler-ssr": "3.4.27",
-				"@vue/shared": "3.4.27",
+				"@babel/parser": "^7.25.3",
+				"@vue/compiler-core": "3.5.13",
+				"@vue/compiler-dom": "3.5.13",
+				"@vue/compiler-ssr": "3.5.13",
+				"@vue/shared": "3.5.13",
 				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.10",
-				"postcss": "^8.4.38",
+				"magic-string": "^0.30.11",
+				"postcss": "^8.4.48",
 				"source-map-js": "^1.2.0"
-			},
-			"dependencies": {
-				"@vue/compiler-dom": {
-					"version": "3.4.27",
-					"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
-					"integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
-					"requires": {
-						"@vue/compiler-core": "3.4.27",
-						"@vue/shared": "3.4.27"
-					}
-				}
 			}
 		},
 		"@vue/compiler-ssr": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
-			"integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
+			"integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
 			"requires": {
-				"@vue/compiler-dom": "3.4.27",
-				"@vue/shared": "3.4.27"
-			},
-			"dependencies": {
-				"@vue/compiler-dom": {
-					"version": "3.4.27",
-					"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
-					"integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
-					"requires": {
-						"@vue/compiler-core": "3.4.27",
-						"@vue/shared": "3.4.27"
-					}
-				}
+				"@vue/compiler-dom": "3.5.13",
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"@vue/compiler-vue2": {
@@ -17594,16 +17517,16 @@
 			}
 		},
 		"@vue/language-core": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.6.tgz",
-			"integrity": "sha512-MW569cSky9R/ooKMh6xa2g1D0AtRKbL56k83dzus/bx//RDJk24RHWkMzbAlXjMdDNyxAaagKPRquBIxkxlCkg==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.0.tgz",
+			"integrity": "sha512-O1ZZFaaBGkKbsRfnVH1ifOK1/1BUkyK+3SQsfnh6PmMmD4qJcTU8godCeA96jjDRTL6zgnK7YzCHfaUlH2r0Mw==",
 			"dev": true,
 			"requires": {
-				"@volar/language-core": "~2.4.1",
-				"@vue/compiler-dom": "^3.4.0",
+				"@volar/language-core": "~2.4.11",
+				"@vue/compiler-dom": "^3.5.0",
 				"@vue/compiler-vue2": "^2.7.16",
-				"@vue/shared": "^3.4.0",
-				"computeds": "^0.0.1",
+				"@vue/shared": "^3.5.0",
+				"alien-signals": "^0.4.9",
 				"minimatch": "^9.0.3",
 				"muggle-string": "^0.4.1",
 				"path-browserify": "^1.0.1"
@@ -17630,45 +17553,46 @@
 			}
 		},
 		"@vue/reactivity": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
-			"integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
+			"integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
 			"requires": {
-				"@vue/shared": "3.4.27"
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"@vue/runtime-core": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
-			"integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
+			"integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
 			"requires": {
-				"@vue/reactivity": "3.4.27",
-				"@vue/shared": "3.4.27"
+				"@vue/reactivity": "3.5.13",
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"@vue/runtime-dom": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
-			"integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
+			"integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
 			"requires": {
-				"@vue/runtime-core": "3.4.27",
-				"@vue/shared": "3.4.27",
+				"@vue/reactivity": "3.5.13",
+				"@vue/runtime-core": "3.5.13",
+				"@vue/shared": "3.5.13",
 				"csstype": "^3.1.3"
 			}
 		},
 		"@vue/server-renderer": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
-			"integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
+			"integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
 			"requires": {
-				"@vue/compiler-ssr": "3.4.27",
-				"@vue/shared": "3.4.27"
+				"@vue/compiler-ssr": "3.5.13",
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"@vue/shared": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
-			"integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA=="
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+			"integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ=="
 		},
 		"@vue/test-utils": {
 			"version": "2.4.6",
@@ -17695,23 +17619,23 @@
 			}
 		},
 		"@wikimedia/codex": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/@wikimedia/codex/-/codex-1.16.0.tgz",
-			"integrity": "sha512-dhic5AMcVcuDsNHv/HKKyOJG059BbyucfuWJutEWNhbmAsk/eixE2Jazvp9sOel+4H5sMjP4kppjKzGt66JdbA==",
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex/-/codex-1.20.0.tgz",
+			"integrity": "sha512-O97rzmVeI/lwldNhXOKRCqUgsQTVUS5xm4QQBSu/r7ldf5rjE4kmEC+DtWaqT2uXGzy69v+Yv+tgajZ1BJPZdw==",
 			"requires": {
 				"@floating-ui/vue": "1.0.6",
-				"@wikimedia/codex-icons": "1.16.0"
+				"@wikimedia/codex-icons": "1.20.0"
 			}
 		},
 		"@wikimedia/codex-design-tokens": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/@wikimedia/codex-design-tokens/-/codex-design-tokens-1.16.0.tgz",
-			"integrity": "sha512-/IjiyMVKbPxEMH+uJvMxIpJhOvjmo4jgOxw80kakBrnDV3aQl+bYhhtk5slbWMw/xatqkzgKsuBIBOFq7xLx1Q=="
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-design-tokens/-/codex-design-tokens-1.20.0.tgz",
+			"integrity": "sha512-3Z5nngMIaIdDClzMQO1FL8HmGcONWUbX8YgM/2nuBy3xuCns7UPp+oQi8+2+wqKd9HpLF+dxHY5+m23GE8LMuQ=="
 		},
 		"@wikimedia/codex-icons": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/@wikimedia/codex-icons/-/codex-icons-1.16.0.tgz",
-			"integrity": "sha512-iMEJaETNwkFMG2VE0UNrS9Pv7JTrY184xLAd4FDPpy3icxPrVw/iDJ4tGTr1HrMVhC2JKApdLDRHyHtkMdZxNg=="
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/@wikimedia/codex-icons/-/codex-icons-1.20.0.tgz",
+			"integrity": "sha512-MAcSLU3fEKXJkHu7dB1eBWFWPTmEbVxHi8+BfKDDpQ7zAvrpq89PAlkKutbD6lmrx5Z8rd6b53ePvlPooYwEiQ=="
 		},
 		"@wmde/eslint-config-wikimedia-typescript": {
 			"version": "0.2.12",
@@ -17798,6 +17722,12 @@
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
 			}
+		},
+		"alien-signals": {
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.4.14.tgz",
+			"integrity": "sha512-itUAVzhczTmP2U5yX67xVpsbbOiquusbWVyA9N+sy6+r6YVbFkahXvNCeEPWEOMhwDYwbVbGHFkVL03N9I5g+Q==",
+			"dev": true
 		},
 		"ansi-colors": {
 			"version": "4.1.3",
@@ -18471,12 +18401,6 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
 			"integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
-			"dev": true
-		},
-		"computeds": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
-			"integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
 			"dev": true
 		},
 		"concat-map": {
@@ -23272,9 +23196,9 @@
 			}
 		},
 		"magic-string": {
-			"version": "0.30.11",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-			"integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+			"version": "0.30.17",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
 			"requires": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
@@ -25638,26 +25562,15 @@
 			"dev": true
 		},
 		"vue": {
-			"version": "3.4.27",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
-			"integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
+			"version": "3.5.13",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
+			"integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
 			"requires": {
-				"@vue/compiler-dom": "3.4.27",
-				"@vue/compiler-sfc": "3.4.27",
-				"@vue/runtime-dom": "3.4.27",
-				"@vue/server-renderer": "3.4.27",
-				"@vue/shared": "3.4.27"
-			},
-			"dependencies": {
-				"@vue/compiler-dom": {
-					"version": "3.4.27",
-					"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
-					"integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
-					"requires": {
-						"@vue/compiler-core": "3.4.27",
-						"@vue/shared": "3.4.27"
-					}
-				}
+				"@vue/compiler-dom": "3.5.13",
+				"@vue/compiler-sfc": "3.5.13",
+				"@vue/runtime-dom": "3.5.13",
+				"@vue/server-renderer": "3.5.13",
+				"@vue/shared": "3.5.13"
 			}
 		},
 		"vue-component-type-helpers": {
@@ -25690,31 +25603,19 @@
 			}
 		},
 		"vue-tsc": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.1.6.tgz",
-			"integrity": "sha512-f98dyZp5FOukcYmbFpuSCJ4Z0vHSOSmxGttZJCsFeX0M4w/Rsq0s4uKXjcSRsZqsRgQa6z7SfuO+y0HVICE57Q==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.0.tgz",
+			"integrity": "sha512-gtmM1sUuJ8aSb0KoAFmK9yMxb8TxjewmxqTJ1aKphD5Cbu0rULFY6+UQT51zW7SpUcenfPUuflKyVwyx9Qdnxg==",
 			"dev": true,
 			"requires": {
-				"@volar/typescript": "~2.4.1",
-				"@vue/language-core": "2.1.6",
-				"semver": "^7.5.4"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.5.4",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-					"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
+				"@volar/typescript": "~2.4.11",
+				"@vue/language-core": "2.2.0"
 			}
 		},
 		"vuex": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/vuex/-/vuex-4.0.2.tgz",
-			"integrity": "sha512-M6r8uxELjZIK8kTKDGgZTYX/ahzblnzC4isU1tpmEuOIIKmV+TRdc+H4s8ds2NuZ7wpUTdGRzJRtoj+lI+pc0Q==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
+			"integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
 			"requires": {
 				"@vue/devtools-api": "^6.0.0-beta.11"
 			}

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
 		"node": ">=16"
 	},
 	"dependencies": {
-		"@wikimedia/codex": "^1.16.0",
-		"@wikimedia/codex-design-tokens": "^1.16.0",
+		"@wikimedia/codex": "^1.20.0",
+		"@wikimedia/codex-design-tokens": "^1.20.0",
 		"@wmde/wikibase-datamodel-types": "^0.2.0",
 		"jest-environment-jsdom": "^29.7.0",
-		"vue": "3.4.27",
-		"vuex": "4.0.2"
+		"vue": "^3.5.13",
+		"vuex": "^4.1.0"
 	},
 	"devDependencies": {
 		"@namics/stylelint-bem": "^10.1.0",
@@ -60,7 +60,7 @@
 		"@vitejs/plugin-vue": "^5.2.1",
 		"@vue/compiler-dom": "^3.5.13",
 		"@vue/eslint-config-typescript": "^13.0.0",
-		"@vue/server-renderer": "3.4.27",
+		"@vue/server-renderer": "^3.5.13",
 		"@vue/test-utils": "^2.4.6",
 		"@vue/vue3-jest": "^29.2.6",
 		"@wmde/eslint-config-wikimedia-typescript": "^0.2.12",
@@ -88,7 +88,7 @@
 		"typescript": "^5.6.3",
 		"vite": "^6.0.7",
 		"vite-plugin-banner": "^0.8.0",
-		"vue-tsc": "^2.1.6"
+		"vue-tsc": "^2.2.0"
 	},
 	"lint-staged": {
 		"*.{js,ts,vue}": [

--- a/tests/unit/components/SpellingVariantInput.test.ts
+++ b/tests/unit/components/SpellingVariantInput.test.ts
@@ -26,7 +26,7 @@ function createLookup( config: Record<string, unknown> = {} ) {
 	} );
 	return mount( SpellingVariantInput, {
 		props: {
-			modelValue: '',
+			searchInput: '',
 		},
 		global: {
 			plugins: [ store ],
@@ -119,7 +119,7 @@ describe( 'SpellingVariantInput', () => {
 			} );
 			const lookup = mount( SpellingVariantInput, {
 				props: {
-					modelValue: '',
+					searchInput: '',
 				},
 				global: {
 					plugins: [ store ],

--- a/tests/unit/components/__snapshots__/AnonymousEditWarning.test.ts.snap
+++ b/tests/unit/components/__snapshots__/AnonymousEditWarning.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`AnonymousEditWarning matches snapshot if anonymous 1`] = `
 "<transition-stub name="cdx-message" leaveactiveclass="" appear="false" persisted="false" css="true" class="wbl-snl-anonymous-edit-warning">
-  <div class="cdx-message cdx-message--block cdx-message--warning" aria-live="polite"><span class="cdx-icon cdx-icon--medium cdx-message__icon--vue"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><!--v-if--><g><path d="M11.53 2.3A1.85 1.85 0 0010 1.21 1.85 1.85 0 008.48 2.3L.36 16.36C-.48 17.81.21 19 1.88 19h16.24c1.67 0 2.36-1.19 1.52-2.64zM11 16H9v-2h2zm0-4H9V6h2z"></path></g></svg></span>
+  <div class="cdx-message cdx-message--block cdx-message--warning" aria-live="polite"><span class="cdx-icon cdx-icon--medium cdx-message__icon--vue"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><!--v-if--><g><path d="M11.53 2.3A1.85 1.85 0 0010 1.21 1.85 1.85 0 008.48 2.3L.36 16.36C-.48 17.81.21 19 1.88 19h16.24c1.67 0 2.36-1.19 1.52-2.64zM11 16H9v-2h2zm0-4H9V6h2z"></path></g></svg></span>
     <div class="cdx-message__content">
       <!-- eslint-disable-next-line vue/no-v-html --><span>(wikibase-anonymouseditwarning, loginLink, createAccountLink)</span>
     </div>
@@ -13,7 +13,7 @@ exports[`AnonymousEditWarning matches snapshot if anonymous 1`] = `
 
 exports[`AnonymousEditWarning uses alternative message if tempuser is enabled 1`] = `
 "<transition-stub name="cdx-message" leaveactiveclass="" appear="false" persisted="false" css="true" class="wbl-snl-anonymous-edit-warning">
-  <div class="cdx-message cdx-message--block cdx-message--warning" aria-live="polite"><span class="cdx-icon cdx-icon--medium cdx-message__icon--vue"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><!--v-if--><g><path d="M11.53 2.3A1.85 1.85 0 0010 1.21 1.85 1.85 0 008.48 2.3L.36 16.36C-.48 17.81.21 19 1.88 19h16.24c1.67 0 2.36-1.19 1.52-2.64zM11 16H9v-2h2zm0-4H9V6h2z"></path></g></svg></span>
+  <div class="cdx-message cdx-message--block cdx-message--warning" aria-live="polite"><span class="cdx-icon cdx-icon--medium cdx-message__icon--vue"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" aria-hidden="true"><!--v-if--><g><path d="M11.53 2.3A1.85 1.85 0 0010 1.21 1.85 1.85 0 008.48 2.3L.36 16.36C-.48 17.81.21 19 1.88 19h16.24c1.67 0 2.36-1.19 1.52-2.64zM11 16H9v-2h2zm0-4H9V6h2z"></path></g></svg></span>
     <div class="cdx-message__content">
       <!-- eslint-disable-next-line vue/no-v-html --><span>(wikibase-anonymouseditnotificationtempuser, loginLink, createAccountLink)</span>
     </div>


### PR DESCRIPTION
I needed to use `--legacy-peer-deps` here as npm seemingly doesn't allow installing/ updating a package and its peer dependencies (@wikimedia/codex which has a peer dependency on vue, thus they would need to be updated in a single transaction). This seems to be desired behaviour, per: npm/cli#7719 (comment)

`npm install --legacy-peer-deps vue@3.5.13 vue-tsc@2.2.0 vuex@4.1.0 @wikimedia/codex@1.20.0 @wikimedia/codex-design-tokens@1.20.0 @vue/server-renderer@3.5.13`

Also some, seemingly harmless, changes in tests where needed. 

Bug: T382330