### PR TITLE
Remove console log warning supression in test suite

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,9 +9,6 @@ module.exports = {
 		'^@/(.*)$': '<rootDir>/src/$1',
 		'\\.css$': '<rootDir>/tests/mocks/styleMock.js',
 	},
-	setupFiles: [
-		'./jest.overrides.js',
-	],
 	testEnvironment: 'jsdom',
 	testEnvironmentOptions: {
 		customExportConditions: [ 'node', 'node-addons' ],

--- a/jest.overrides.js
+++ b/jest.overrides.js
@@ -1,6 +1,0 @@
-( function () {
-	// eslint-disable-next-line no-console
-	console.warn = function () {
-		// ignore @vue/compat warnings
-	};
-}() );

--- a/tests/unit/components/ItemLookup.test.ts
+++ b/tests/unit/components/ItemLookup.test.ts
@@ -16,6 +16,7 @@ function createLookup( propsOverrides: any = {} ): VueWrapper<any> {
 			placeholder: 'some placeholder',
 			searchForItems: jest.fn(),
 			value: null,
+			searchInput: 'input',
 			...propsOverrides,
 		},
 	} );

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -9,13 +9,13 @@ describe( 'createAndMount', () => {
 
 	it( 'mounts created app on given selector', () => {
 		const rootElement = document.createElement( 'div' );
-		rootElement.id = 'test-app';
+		rootElement.id = 'wbl-snl-intro-text-wrapper';
 		document.body.append( rootElement );
 		const discardedElement = document.createElement( 'div' );
 		rootElement.append( discardedElement );
 
 		const instance = createAndMount( {
-			rootSelector: '#test-app',
+			rootSelector: '#wbl-snl-intro-text-wrapper',
 			isAnonymous: false,
 			licenseUrl: '',
 			licenseName: '',


### PR DESCRIPTION
Because of previous vue compatibility issues (T355239) we have been suppressing console log warnings during test suite execution. Now that we no longer have vue compat issues, we can remove the log suppression.

Remove the log supression, and fix resulting warnings that have previously been invisible.

Bug: T355168