### PR TITLE
Avoid compiling color constants to static values for dark-mode

### DIFF
--- a/src/components/NewLexemeForm.vue
+++ b/src/components/NewLexemeForm.vue
@@ -194,7 +194,7 @@ const onSubmit = async () => {
 	border-style: theme-wikimedia-ui.$border-style-base;
 	border-width: theme-wikimedia-ui.$border-width-base;
 	border-radius: theme-wikimedia-ui.$border-radius-base;
-	border-color: theme-wikimedia-ui.$border-color-muted;
+	border-color: var( --border-color-muted );
 
 	& > * + * {
 		margin-top: var( --dimension-layout-xsmall );
@@ -207,7 +207,7 @@ const onSubmit = async () => {
 	font-size: theme-wikimedia-ui.$font-size-small;
 	font-weight: theme-wikimedia-ui.$font-weight-normal;
 	line-height: theme-wikimedia-ui.$line-height-medium;
-	color: theme-wikimedia-ui.$color-base;
+	color: var( --color-base );
 	margin-bottom: 0;
 }
 

--- a/src/components/SearchExisting.vue
+++ b/src/components/SearchExisting.vue
@@ -33,7 +33,7 @@ const searchMessage = computed( () => messages.get(
 	font-size: theme-wikimedia-ui.$font-size-small;
 	font-weight: theme-wikimedia-ui.$font-weight-normal;
 	line-height: theme-wikimedia-ui.$line-height-medium;
-	color: theme-wikimedia-ui.$color-base;
+	color: var( --color-base );
 
 	/* margins */
 	margin-top: var( --dimension-layout-xsmall );


### PR DESCRIPTION
SpecialNewLexeme is substantially built using Codex components, which automatically have correct colour variables and support for darkmode. In codex itself, components are styled using LESS (`<style lang="less">`) which allows variables in the stylesheets to refer to their dynamic values in the compiled code.

For components that are specific to SpecialNewLexeme, we have used SCSS (`<style lang="scss">`) and imported the codex variables via codex's CSS export. Referring to these values (e.g. `$color-base`) from SCSS evaluates the current value of the variable at compile time and hard-codes that into the generated Vue code.

Use the CSS variables (`var( --border-color-muted )`) to refer to codex colour values from SCSS so that the darkmode skin can override the colour values at runtime.

Bug: T385046